### PR TITLE
feat: analysis type picker when adding a new box

### DIFF
--- a/src/lib/DynBoxRow.svelte
+++ b/src/lib/DynBoxRow.svelte
@@ -5,7 +5,7 @@
 
   const md = new MediaQuery("min-width: 768px");
 
-  type Box = {
+  export type Box = {
     id: number;
     idx: number;
     col: number;
@@ -37,7 +37,7 @@
   }: {
     children: Snippet<[{ box: Box }]>;
     items: BoxSeed[];
-    onAdd: (box: Box) => number;
+    onAdd: (box: Box) => void;
     onRemove: (box: Box) => void;
   } = $props();
 
@@ -188,10 +188,7 @@
       span: GRID_COLS - col + 1,
       title: `Analysis ${nextId}`,
     };
-    newBox.idx = onAdd(newBox);
-
-    // boxes[row] = [...boxes[row], newBox];
-    // boxes = boxes.slice();
+    onAdd(newBox);
   }
 
   function addBelow() {
@@ -202,8 +199,7 @@
       span: DEFAULT_COL_SPAN,
       title: `Analysis ${nextId}`,
     };
-    newBox.idx = onAdd(newBox);
-    // boxes = [...boxes, [newBox]];
+    onAdd(newBox);
   }
 
   function getGridMetrics() {

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -5,7 +5,7 @@
     size,
     children,
     popovertarget,
-    el = $bindable<HTMLDivElement | null>(null),
+    el = $bindable<HTMLDivElement | null | undefined>(),
   }: {
     size: "xs" | "sm" | "md" | "lg";
     popovertarget: string;

--- a/src/lib/Popover.svelte
+++ b/src/lib/Popover.svelte
@@ -5,15 +5,18 @@
     size,
     children,
     popovertarget,
+    el = $bindable<HTMLDivElement | null>(null),
   }: {
-    size: "sm" | "md" | "lg";
+    size: "xs" | "sm" | "md" | "lg";
     popovertarget: string;
     children: Snippet;
+    el?: HTMLDivElement | null;
   } = $props();
 </script>
 
 <div
   popover
+  bind:this={el}
   id={popovertarget}
   class={size}
 >
@@ -33,6 +36,12 @@
   }
   [popover]::backdrop {
     background-color: rgba(0, 0, 0, 0.5);
+  }
+  .xs {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(22rem, calc(100vw - 2rem));
   }
   .sm {
     --width: 60rem;

--- a/src/lib/model-editor/AnalysesDashboard.svelte
+++ b/src/lib/model-editor/AnalysesDashboard.svelte
@@ -7,7 +7,7 @@
   } from "$lib";
   import ModelEditButton from "$lib/buttons/ModelEditButton.svelte";
   import ResetButton from "$lib/buttons/ResetButton.svelte";
-  import DynBoxRow from "$lib/DynBoxRow.svelte";
+  import DynBoxRow, { type Box } from "$lib/DynBoxRow.svelte";
   import Icon from "$lib/Icon.svelte";
   import Math from "$lib/Math.svelte";
   import { ModelBuilder } from "$lib/model-editor/modelBuilder";
@@ -96,6 +96,7 @@
 
   let fileInput = $state<HTMLInputElement | null>(null);
   let loadError = $state<string | null>(null);
+  let pendingBox = $state<Box | null>(null);
 
   function saveModel() {
     const xml = modelToSbml(model, name);
@@ -124,18 +125,39 @@
     input.value = "";
   }
 
-  function addParameterScan() {
-    const newId = analyses.length;
-    const firstParam = [...model.parameters.keys()][0] ?? "";
+  function handleAdd(box: Box) {
+    pendingBox = box;
+    document.getElementById("add-analysis-picker")?.showPopover();
+  }
+
+  function addTimeCourse(box: Box) {
+    const newAnalysis: SimulationAnalysis = {
+      type: "simulation",
+      id: box.id,
+      idx: analyses.length,
+      title: "New",
+      span: box.span,
+      tEnd: 10,
+      yMin: undefined,
+      yMax: undefined,
+      xMin: undefined,
+      xMax: undefined,
+      timeoutInSeconds: 20,
+    };
+    analyses = [...analyses, newAnalysis];
+  }
+
+  function addParameterScan(box: Box) {
+    const firstParam = model.parameters.keys().next().value ?? "";
     const newScan: ParameterScanAnalysis = {
       type: "parameterScan",
-      id: newId,
+      id: box.id,
       idx: analyses.length,
       title: `Parameter Scan`,
       span: 3,
       parameter: firstParam,
       min: 0,
-      max: 1,
+      max: 10,
       steps: 20,
       tEnd: 10_000,
       tolerance: 1e-4,
@@ -166,8 +188,14 @@
     >
   </Pair>
   <Pair justify="end">
-    <button class="secondary" onclick={() => fileInput?.click()}>Load</button>
-    <button class="secondary" onclick={saveModel}>Save</button>
+    <button
+      class="secondary"
+      onclick={() => fileInput?.click()}>Load</button
+    >
+    <button
+      class="secondary"
+      onclick={saveModel}>Save</button
+    >
     <ResetButton
       onclick={() => {
         model = initModel();
@@ -187,6 +215,46 @@
 {#if loadError}
   <p class="load-error">{loadError}</p>
 {/if}
+
+<div
+  popover
+  id="add-analysis-picker"
+  class="picker-popover"
+>
+  <p class="picker-title">Add analysis</p>
+  <div class="picker-options">
+    <button
+      class="picker-option"
+      onclick={() => {
+        if (pendingBox) {
+          addTimeCourse(pendingBox);
+          pendingBox = null;
+        }
+        document.getElementById("add-analysis-picker")?.hidePopover();
+      }}
+    >
+      <Icon>show_chart</Icon>
+      Time Course
+    </button>
+    <button
+      class="picker-option"
+      onclick={() => {
+        if (pendingBox) {
+          addParameterScan(pendingBox);
+          const id = pendingBox.id;
+          pendingBox = null;
+          document.getElementById("add-analysis-picker")?.hidePopover();
+          setTimeout(() => {
+            document.getElementById(`analysis-editor-${id}`)?.showPopover();
+          }, 0);
+        }
+      }}
+    >
+      <Icon>stacked_line_chart</Icon>
+      Parameter Scan
+    </button>
+  </div>
+</div>
 
 {#if children}
   {@render children()}
@@ -270,23 +338,7 @@
 
 <DynBoxRow
   items={analyses}
-  onAdd={(box) => {
-    const newAnalysis: SimulationAnalysis = {
-      type: "simulation",
-      id: box.id,
-      idx: analyses.length,
-      title: "New",
-      span: box.span,
-      tEnd: 10,
-      yMin: undefined,
-      yMax: undefined,
-      xMin: undefined,
-      xMax: undefined,
-      timeoutInSeconds: 20,
-    };
-    analyses = [...analyses, newAnalysis];
-    return analyses.length - 1;
-  }}
+  onAdd={handleAdd}
   onRemove={(box) => {
     analyses = analyses.filter((a) => a.id !== box.id);
     delete simulatorRefs[box.id];
@@ -384,9 +436,9 @@
     background-color: color-mix(in srgb, var(--primary) 10%, transparent);
   }
   .load-error {
+    margin: 0;
     color: var(--error, #dc2626);
     font-size: 0.875rem;
-    margin: 0;
   }
   .grid-row {
     display: flex;
@@ -411,6 +463,49 @@
     font-weight: 400;
   }
   a.light:hover {
+    color: var(--primary);
+  }
+  .picker-popover {
+    position: fixed;
+    inset: 50% auto auto 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: var(--shadow);
+    border: var(--border-heavy);
+    border-radius: var(--border-radius);
+    background: var(--bg-l1);
+    padding: 1.5rem;
+    min-width: 18rem;
+  }
+  .picker-popover::backdrop {
+    background-color: rgba(0, 0, 0, 0.3);
+  }
+  .picker-title {
+    margin: 0 0 1rem;
+    font-weight: 600;
+    font-size: 1rem;
+  }
+  .picker-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .picker-option {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    border: var(--border);
+    border-radius: var(--border-radius);
+    background: transparent;
+    padding: 0.75rem 1rem;
+    width: 100%;
+    font-size: 0.9rem;
+    text-align: left;
+    transition: background 0.15s ease;
+  }
+  .picker-option:hover {
+    background: color-mix(in srgb, var(--primary) 10%, transparent);
+    border-color: var(--primary);
     color: var(--primary);
   }
 </style>

--- a/src/lib/model-editor/AnalysesDashboard.svelte
+++ b/src/lib/model-editor/AnalysesDashboard.svelte
@@ -98,8 +98,8 @@
   let fileInput = $state<HTMLInputElement | null>(null);
   let loadError = $state<string | null>(null);
   let pendingBox = $state<Box | null>(null);
-  let pickerEl = $state<HTMLDivElement | null>(null);
-  let analysisEditorEls = $state<Record<number, HTMLDivElement | null>>({});
+  let pickerEl = $state<HTMLDivElement | null | undefined>(null);
+  let analysisEditorEls = $state<Record<number, HTMLDivElement | null | undefined>>({});
 
   function saveModel() {
     const xml = modelToSbml(model, name);
@@ -476,6 +476,7 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    transition: background 0.15s ease;
     cursor: pointer;
     border: var(--border);
     border-radius: var(--border-radius);
@@ -484,11 +485,10 @@
     width: 100%;
     font-size: 0.9rem;
     text-align: left;
-    transition: background 0.15s ease;
   }
   .picker-option:hover {
-    background: color-mix(in srgb, var(--primary) 10%, transparent);
     border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 10%, transparent);
     color: var(--primary);
   }
 </style>

--- a/src/lib/model-editor/AnalysesDashboard.svelte
+++ b/src/lib/model-editor/AnalysesDashboard.svelte
@@ -17,6 +17,7 @@
   import Simulator from "$lib/simulations/TimeCourse.svelte";
   import Slider from "$lib/Slider.svelte";
   import type { Snippet } from "svelte";
+  import { tick } from "svelte";
   import Popover from "../Popover.svelte";
   import ParameterScanEditor from "../simulations/ParameterScanEditor.svelte";
   import AnalysisEditor from "../simulations/TimeCourseEditor.svelte";
@@ -97,6 +98,8 @@
   let fileInput = $state<HTMLInputElement | null>(null);
   let loadError = $state<string | null>(null);
   let pendingBox = $state<Box | null>(null);
+  let pickerEl = $state<HTMLDivElement | null>(null);
+  let analysisEditorEls = $state<Record<number, HTMLDivElement | null>>({});
 
   function saveModel() {
     const xml = modelToSbml(model, name);
@@ -127,7 +130,7 @@
 
   function handleAdd(box: Box) {
     pendingBox = box;
-    document.getElementById("add-analysis-picker")?.showPopover();
+    pickerEl?.showPopover();
   }
 
   function addTimeCourse(box: Box) {
@@ -216,45 +219,43 @@
   <p class="load-error">{loadError}</p>
 {/if}
 
-<div
-  popover
-  id="add-analysis-picker"
-  class="picker-popover"
+<Popover
+  size="xs"
+  popovertarget="add-analysis-picker"
+  bind:el={pickerEl}
 >
   <p class="picker-title">Add analysis</p>
-  <div class="picker-options">
-    <button
-      class="picker-option"
-      onclick={() => {
-        if (pendingBox) {
-          addTimeCourse(pendingBox);
-          pendingBox = null;
-        }
-        document.getElementById("add-analysis-picker")?.hidePopover();
-      }}
-    >
-      <Icon>show_chart</Icon>
-      Time Course
-    </button>
-    <button
-      class="picker-option"
-      onclick={() => {
-        if (pendingBox) {
-          addParameterScan(pendingBox);
-          const id = pendingBox.id;
-          pendingBox = null;
-          document.getElementById("add-analysis-picker")?.hidePopover();
-          setTimeout(() => {
-            document.getElementById(`analysis-editor-${id}`)?.showPopover();
-          }, 0);
-        }
-      }}
-    >
-      <Icon>stacked_line_chart</Icon>
-      Parameter Scan
-    </button>
-  </div>
-</div>
+  <button
+    class="picker-option"
+    onclick={async () => {
+      if (!pendingBox) return;
+      addTimeCourse(pendingBox);
+      const id = pendingBox.id;
+      pendingBox = null;
+      pickerEl?.hidePopover();
+      await tick();
+      analysisEditorEls[id]?.showPopover();
+    }}
+  >
+    <Icon>show_chart</Icon>
+    Time Course
+  </button>
+  <button
+    class="picker-option"
+    onclick={async () => {
+      if (!pendingBox) return;
+      addParameterScan(pendingBox);
+      const id = pendingBox.id;
+      pendingBox = null;
+      pickerEl?.hidePopover();
+      await tick();
+      analysisEditorEls[id]?.showPopover();
+    }}
+  >
+    <Icon>stacked_line_chart</Icon>
+    Parameter Scan
+  </button>
+</Popover>
 
 {#if children}
   {@render children()}
@@ -388,6 +389,7 @@
   <Popover
     size="sm"
     popovertarget={`analysis-editor-${analysis.id}`}
+    bind:el={analysisEditorEls[analysis.id]}
   >
     {#if analysis.type === "simulation"}
       <AnalysisEditor
@@ -465,29 +467,10 @@
   a.light:hover {
     color: var(--primary);
   }
-  .picker-popover {
-    position: fixed;
-    inset: 50% auto auto 50%;
-    transform: translate(-50%, -50%);
-    box-shadow: var(--shadow);
-    border: var(--border-heavy);
-    border-radius: var(--border-radius);
-    background: var(--bg-l1);
-    padding: 1.5rem;
-    min-width: 18rem;
-  }
-  .picker-popover::backdrop {
-    background-color: rgba(0, 0, 0, 0.3);
-  }
   .picker-title {
-    margin: 0 0 1rem;
+    margin: 0;
     font-weight: 600;
     font-size: 1rem;
-  }
-  .picker-options {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
   }
   .picker-option {
     display: flex;


### PR DESCRIPTION
## Summary

- The `+` button in `DynBoxRow` now opens a small native popover asking which analysis type to add
- Options: **Time Course** and **Parameter Scan**
- Adding a Parameter Scan automatically opens its editor popover so the user can configure the parameter/range immediately
- `DynBoxRow.onAdd` return type changed from `number` to `void` (return value was unused — boxes update via Svelte reactivity from `items`)

## Test plan

- [ ] Click `+` in the analysis grid — picker popup should appear
- [ ] Choose "Time Course" — a new time course box is added
- [ ] Choose "Parameter Scan" — a new parameter scan box is added and its editor opens automatically
- [ ] Clicking backdrop/Escape dismisses the picker without adding anything