### PR TITLE
fix: resolve all TypeScript type errors from npm run check

### DIFF
--- a/src/lib/mathml/unary.ts
+++ b/src/lib/mathml/unary.ts
@@ -15,7 +15,7 @@ export class Abs extends Unary {
     return `abs(${this.child.toPy(displayNames)})`;
   }
   toTex(texNames: Map<string, string>): string {
-    return `abs(${this.child.toPy(displayNames)})`;
+    return `abs(${this.child.toTex(texNames)})`;
   }
   toSBML(): string {
     return `<apply><abs/>${this.child.toSBML()}</apply>`;

--- a/src/routes/dev/analysis-editor/+page.svelte
+++ b/src/routes/dev/analysis-editor/+page.svelte
@@ -1,10 +1,18 @@
-<script>
+<script lang="ts">
   import AnalysisEditor from "$lib/simulations/TimeCourseEditor.svelte";
 
   let analysis = {
+    type: "simulation" as const,
+    id: 0,
+    idx: 0,
     title: "",
+    span: 1,
     tEnd: 1.0,
+    xMin: undefined,
+    xMax: undefined,
+    yMin: undefined,
     yMax: 20.0,
+    timeoutInSeconds: 10,
   };
 </script>
 

--- a/src/routes/dev/eq-editor/+page.svelte
+++ b/src/routes/dev/eq-editor/+page.svelte
@@ -16,55 +16,11 @@
   }
 
   const variables: VarView = [
-    ["S", { value: 1.0 }],
-    [
-      "kcat",
-      {
-        value: 1.0,
-        texName: "k_{cat}", //
-        slider: {
-          min: "0",
-          max: "1.0",
-          step: "0.1",
-        },
-      },
-    ],
-    [
-      "km",
-      {
-        value: 1.0,
-        texName: "k_{M}", //
-        slider: {
-          min: "0",
-          max: "1.0",
-          step: "0.1",
-        },
-      },
-    ],
-    [
-      "e0",
-      {
-        value: 1.0,
-        texName: "e_{0}", //
-        slider: {
-          min: "0",
-          max: "1.0",
-          step: "0.1",
-        },
-      },
-    ],
-    [
-      "vmax",
-      {
-        value: 1.0,
-        texName: "V_{max}", //
-        slider: {
-          min: "0",
-          max: "1.0",
-          step: "0.1",
-        },
-      },
-    ],
+    { id: "S", value: 1.0, texName: "S" },
+    { id: "kcat", value: 1.0, texName: "k_{cat}", slider: { min: "0", max: "1.0", step: "0.1" } },
+    { id: "km", value: 1.0, texName: "k_{M}", slider: { min: "0", max: "1.0", step: "0.1" } },
+    { id: "e0", value: 1.0, texName: "e_{0}", slider: { min: "0", max: "1.0", step: "0.1" } },
+    { id: "vmax", value: 1.0, texName: "V_{max}", slider: { min: "0", max: "1.0", step: "0.1" } },
   ];
   const parameters: ParView = [];
   const assignments: AssView = [];

--- a/src/routes/dev/model-edit/+page.svelte
+++ b/src/routes/dev/model-edit/+page.svelte
@@ -12,12 +12,12 @@
   let userParameters: string[] = [];
 
   let variables: VarView = $state([
-    { id: "x0", value: 1.0 },
-    { id: "x1", value: 1.0 },
+    { id: "x0", value: 1.0, texName: "x_0" },
+    { id: "x1", value: 1.0, texName: "x_1" },
   ]);
   let parameters: ParView = $state([
-    { id: "kf", value: 1.0 },
-    { id: "keq", value: 1.0 },
+    { id: "kf", value: 1.0, texName: "k_f" },
+    { id: "keq", value: 1.0, texName: "k_{eq}" },
   ]);
   let assignments: AssView = $state([
     {

--- a/src/routes/dev/stoich-editor/+page.svelte
+++ b/src/routes/dev/stoich-editor/+page.svelte
@@ -9,9 +9,9 @@
   import StoichEditor from "$lib/model-editor/StoichEditor.svelte";
 
   const variables: VarView = [
-    ["x", { value: 1.0 }],
-    ["y", { value: 1.0 }],
-    ["z", { value: 1.0 }],
+    { id: "x", value: 1.0, texName: "x" },
+    { id: "y", value: 1.0, texName: "y" },
+    { id: "z", value: 1.0, texName: "z" },
   ];
   const parameters: ParView = [];
   const assignments: AssView = [];


### PR DESCRIPTION
## Summary

- Fix `Abs.toTex()` copy-paste bug: was calling `toPy(displayNames)` instead of `toTex(texNames)`
- Update `dev/` page fixtures to use the object format for `Variable`/`Parameter` (these were using an old tuple format `[string, {...}]`; `VarView` is now `Array<Variable>` with a required `texName` field)
- Add missing required fields to `SimulationAnalysis` in `analysis-editor` dev page
- Add `lang="ts"` to `analysis-editor` script tag (needed for `as const` assertion)

## Test plan

- [ ] `npm run check` passes with 0 errors