### PR TITLE
build(deps): update dependencies (2026-08-17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,7 @@
     },
     "node_modules/@computational-biology-aachen/design": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/Computational-Biology-Aachen/design.git#bdcc88e742eb93ad9355326eb225bd750298322c",
-      "integrity": "sha512-rY3APdIwfZphKC2+sVy7U9TtkY4fU5lfUBYsVcbE1ZtCDZzMw1ELJjdz+xgu8/pMUST0My9CPnpCVZisX/QXeQ==",
+      "resolved": "git+ssh://git@github.com/Computational-Biology-Aachen/design.git#53f528d893817a0df0cd022e767815d48c7772ae",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": ">=7.3.1",
         "@fortawesome/free-solid-svg-icons": ">=7.3.1",
@@ -70,7 +69,6 @@
     "node_modules/@computational-biology-aachen/mxlweb-core": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/Computational-Biology-Aachen/mxlweb-core.git#91499e93eedbaab95be22794d4f6a3b468f234e8",
-      "integrity": "sha512-yQrPnuRtzuKDYnOfqqOv/eUVbcNF2cGhbSy08KmMoY6X2kpFh7V4L9JBxJzSxsY7uYWDF5R7PvEdbMl8MejJjw==",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.17.1"
@@ -829,13 +827,13 @@
       }
     },
     "node_modules/@inlang/paraglide-js": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.23.2.tgz",
-      "integrity": "sha512-tzWnZ6DEQ3JRxpSM/lsmfUFSNXLymvlfUei4uX1lo/Qh3a8OfxZ5nchGrEM+p0aLX4m5ZMrVuMKfaD0qXJFeoA==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.24.1.tgz",
+      "integrity": "sha512-r/gak0kY2yuqgz0RFxccb7A89fgcLpiqoEbYfv3nxlqyhdW2v8NajE1A2xiXrv/iAo7WCX4zk8EJAhL69rcp0g==",
       "license": "MIT",
       "dependencies": {
         "@inlang/recommend-sherlock": "^0.2.1",
-        "@inlang/sdk": "^2.10.0",
+        "@inlang/sdk": "^3.0.1",
         "commander": "11.1.0",
         "consola": "3.4.0",
         "json5": "2.2.3",
@@ -868,12 +866,12 @@
       }
     },
     "node_modules/@inlang/sdk": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.10.2.tgz",
-      "integrity": "sha512-O1ki72SNK6LPagaGrvlioBb1mWKvump7cO7P85hfGZjdFTmDdn3icI0A6MvaBsB3P9KQHAjzyubnN1OslGufTw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-3.0.1.tgz",
+      "integrity": "sha512-QvyMYjCqF7CnrTp8ZaPiuwpmxsoQPIDgfqGeWfqi4FDxBREye4QdyaZS4DGwIlCZXybF/YMj0TtL2uBfbmajug==",
       "license": "MIT",
       "dependencies": {
-        "@lix-js/sdk": "0.4.10",
+        "@lix-js/sdk": "0.12.2",
         "@sinclair/typebox": "^0.31.17",
         "kysely": "^0.28.12",
         "sqlite-wasm-kysely": "0.3.0",
@@ -935,33 +933,72 @@
       "license": "MIT"
     },
     "node_modules/@lix-js/sdk": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
-      "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
-      "license": "Apache-2.0",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.12.2.tgz",
+      "integrity": "sha512-sKGOPdVKdChS5q60F4VQE4ZTcf0B7ZJM3KGCVQFN2suVNKhHcllbsCiwRYuM5WL7Yu1ql7YexltJ2FCsDqKePg==",
+      "license": "MIT",
       "dependencies": {
-        "@lix-js/server-protocol-schema": "0.1.1",
-        "dedent": "1.5.1",
-        "human-id": "^4.1.1",
-        "js-sha256": "^0.11.0",
-        "kysely": "^0.28.12",
-        "sqlite-wasm-kysely": "0.3.0",
-        "uuid": "^14.0.0"
+        "fflate": "^0.8.3"
       },
-      "engines": {
-        "node": ">=18"
+      "optionalDependencies": {
+        "@lix-js/sdk-darwin-arm64": "0.12.2",
+        "@lix-js/sdk-linux-arm64": "0.12.2",
+        "@lix-js/sdk-linux-x64": "0.12.2",
+        "@lix-js/sdk-win32-x64": "0.12.2"
       }
     },
-    "node_modules/@lix-js/server-protocol-schema": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lix-js/server-protocol-schema/-/server-protocol-schema-0.1.1.tgz",
-      "integrity": "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==",
-      "license": "Apache-2.0"
+    "node_modules/@lix-js/sdk-darwin-arm64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.12.2.tgz",
+      "integrity": "sha512-0mBRIfgZfaey1/d0mijv7fBIGPeaTIMCDOPr3s4RUlHy/j+llNmAyDS2iNlalFh9nQGys7JNzo2Hv3FQbdKmug==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lix-js/sdk-linux-arm64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.12.2.tgz",
+      "integrity": "sha512-817uJlC2KTIKDaqQvALTu03hEJpNxEA+9d33FNs8sOm9pAguOWiAK1zGA2SD0IgS9Q8NqQeABLb84OesW5/NCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lix-js/sdk-linux-x64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.12.2.tgz",
+      "integrity": "sha512-rA7lw1jBr6azBHR5Sh/RzOKSAlRcmVea7VeI4VQqpy0PZs+5tWoK9iVC41V4oCIKssRv2wrkbvyP3CqInhoknQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lix-js/sdk-win32-x64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.12.2.tgz",
+      "integrity": "sha512-y9IikCdrYx6cFnfqeUvYKPw6KBY016U2F2wYDILYZDZndccK2xw7lJChX163w9PewMwY3GsC/UqRBi5yqFAJ2w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -974,9 +1011,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -990,9 +1027,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -1006,9 +1043,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -1022,9 +1059,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -1038,9 +1075,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -1054,9 +1091,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1107,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
@@ -1086,9 +1123,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1102,9 +1139,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
@@ -1118,9 +1155,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
@@ -1134,9 +1171,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
@@ -1150,9 +1187,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -1166,9 +1203,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -1182,9 +1219,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -1348,9 +1385,9 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.12.tgz",
-      "integrity": "sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
+      "integrity": "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1436,9 +1473,9 @@
       }
     },
     "node_modules/@sveltejs/load-config": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.2.tgz",
-      "integrity": "sha512-K7dsJDQxBOF+f+epuhMactcjK2VP4MRkLKtwSykNtEI+cKVEyzrmmhQ1pmoxI800m4JKcyJ05L2M4yPwAGiBNw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.3.tgz",
+      "integrity": "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1465,9 +1502,9 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
-      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.0.tgz",
+      "integrity": "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2264,20 +2301,6 @@
         }
       }
     },
-    "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2332,9 +2355,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -2426,9 +2449,9 @@
       }
     },
     "node_modules/eslint-plugin-svelte": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.22.0.tgz",
-      "integrity": "sha512-O3qn0NePTWta+1o25dIThqeEP/hEQ3VxDK2LVO8SQ5wG9umLMvulK+m1yQ4JGOb2Pkl8IB0G1lpRV/HXDXSLTQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.23.0.tgz",
+      "integrity": "sha512-n9jRklDqy0+W834568a4ZIZTK7DHXxvvHHxxGP8nNq7N//pOZMubttskHOquyGgfTR4Z05q2NdGNlsTpIEA48w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2579,9 +2602,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.2.tgz",
-      "integrity": "sha512-40GyiEJevYKXzYTHtZkFqAgTjLOuFcaXMao8TPyOlnWTlkHDlvZ6mPMJaJyOqVwrVCgomEG1WhJd81w0X+IcCw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.4.tgz",
+      "integrity": "sha512-CHnJXZDfBeOAjLIGNy/0BEsmDu5+irHgUXRW9pGptxCbO3uyjJ98crilzFgiBqizW94UodjX3GAPLg/dhEnUfA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2697,6 +2720,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2789,9 +2818,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2851,15 +2880,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/human-id": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
-      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
-      "license": "MIT",
-      "bin": {
-        "human-id": "dist/cli.js"
       }
     },
     "node_modules/ignore": {
@@ -2966,12 +2986,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/js-sha256": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
-      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
-      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3716,9 +3730,9 @@
       }
     },
     "node_modules/papaparse": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
-      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.6.0.tgz",
+      "integrity": "sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q==",
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -4010,9 +4024,9 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "314.0.3",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-314.0.3.tgz",
-      "integrity": "sha512-sK40My6m8tmBUYtYH9au9rXUeh9x0wfahtHdOlGmJxZDsKBGKtP6KznyFB2+u/klbQTdDionR0uaVd176zVQzQ==",
+      "version": "314.0.5",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-314.0.5.tgz",
+      "integrity": "sha512-Dl5rvbSMQP0hC3Yp61F+lr4o1vwrWZpapmJajt4KTlGWTeso7WLAp6HOIMC+26NeXjCCEF8dXw7FJ0nfQRTyPg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/emscripten": "^1.41.4",
@@ -4070,12 +4084,12 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.143.0",
+        "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4085,20 +4099,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.3",
-        "@rolldown/binding-darwin-arm64": "1.2.3",
-        "@rolldown/binding-darwin-x64": "1.2.3",
-        "@rolldown/binding-freebsd-x64": "1.2.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-        "@rolldown/binding-linux-arm64-musl": "1.2.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-musl": "1.2.3",
-        "@rolldown/binding-openharmony-arm64": "1.2.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/sade": {
@@ -4297,9 +4311,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.56.8",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
-      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
+      "version": "5.56.9",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.9.tgz",
+      "integrity": "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -4324,14 +4338,14 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.5.tgz",
-      "integrity": "sha512-NnkHGCTPH6k4ka1E9IpTuNv40uLArHnX52kLEuaHSGqRlPYTnkbFs529jSWG+y+wDy+v+jA2PQ0soN1umVK+OA==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.6.tgz",
+      "integrity": "sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@sveltejs/load-config": "^0.2.2",
+        "@sveltejs/load-config": "^0.2.3",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -4349,9 +4363,9 @@
       }
     },
     "node_modules/svelte-eslint-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",
-      "integrity": "sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.1.tgz",
+      "integrity": "sha512-5zgKBqAf6V8Jyrmr1jViksyG4NKT8NheYwkdxRaMRDAqpGWi9wR8ktcGrAZbfMn/PHUp1BWzAp0cYQECkWuAMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4365,7 +4379,7 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-        "pnpm": "10.34.1"
+        "pnpm": "10.34.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
@@ -5184,6 +5198,23 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
Automated dependency update via `npm update`.

## Changed packages

| Package | Old version | New version |
|---------|-------------|-------------|
| @inlang/paraglide-js | 2.23.2 | 2.24.1 |
| @inlang/sdk | 2.10.2 | 3.0.1 |
| @lix-js/sdk | 0.4.10 | 0.12.2 |
| @lix-js/sdk | 0.1.1 | 0.12.2 |
| @lix-js/sdk | 0.1.1 | 0.12.2 |
| @lix-js/sdk | 0.1.1 | 0.12.2 |
| @lix-js/sdk | 0.1.1 | 0.12.2 |
| @oxc-project/types | 0.143.0 | 0.144.0 |
| @rolldown/binding-android-arm64 | 1.2.3 | 1.2.4 |
| @rolldown/binding-darwin-arm64 | 1.2.3 | 1.2.4 |
| @rolldown/binding-darwin-x64 | 1.2.3 | 1.2.4 |
| @rolldown/binding-freebsd-x64 | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-arm-gnueabihf | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-arm64-gnu | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-arm64-musl | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-ppc64-gnu | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-s390x-gnu | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-x64-gnu | 1.2.3 | 1.2.4 |
| @rolldown/binding-linux-x64-musl | 1.2.3 | 1.2.4 |
| @rolldown/binding-openharmony-arm64 | 1.2.3 | 1.2.4 |
| @rolldown/binding-win32-arm64-msvc | 1.2.3 | 1.2.4 |
| @rolldown/binding-win32-x64-msvc | 1.2.3 | 1.2.4 |
| @sveltejs/acorn-typescript | 1.0.12 | 1.0.13 |
| @sveltejs/load-config | 0.2.2 | 0.2.3 |
| @sveltejs/vite-plugin-svelte/node_modules/magic-string | 1.1.0 | 1.2.0 |
| es-module-lexer | 2.3.1 | 2.3.2 |
| eslint-plugin-svelte | 3.22.0 | 3.23.0 |
| esrap | 2.3.2 | 2.3.4 |
| esrap | 2.3.2 | 0.8.3 |
| globals | 17.9.0 | 17.11.0 |
| papaparse | 5.5.4 | 5.6.0 |
| pyodide | 314.0.3 | 314.0.5 |
| rolldown | 1.2.3 | 1.2.4 |
| svelte | 5.56.8 | 5.56.9 |
| svelte-check | 4.7.5 | 4.7.6 |
| svelte-eslint-parser | 1.8.0 | 1.8.1 |
| svelte-eslint-parser | 1.8.0 | 2.9.0 |