### PR TITLE
feat: NN block editor UI and adjoint-based fitting

### DIFF
--- a/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
+++ b/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
@@ -1,0 +1,211 @@
+# ADR 0005: Neural Network Corrections via AST Nodes, and Adjoint-Based Fitting
+
+**Status:** Proposed
+**Scope:** `ModelEditor` (this repo); `mathml/`, `src-c/`, `backends/wasm/` (sibling
+`mxlweb-core` repo)
+
+---
+
+## 1. Context
+
+ADR 0004 established fitting via cminpack's `lmdif`, noting explicitly that "no autodiff
+exists in the mathml AST, and `lmdif` internally does forward-difference Jacobians." That
+constraint is the starting point for this ADR: users want to augment an otherwise-
+mechanistic model with a small neural-network correction term (a universal differential
+equation, UDE) — most concretely for PETC (photosynthetic electron transport chain)
+models, where mechanistic knowledge of some sub-process is incomplete but the rest of the
+kinetic model is well characterized.
+
+Two constraints rule out the obvious approaches:
+
+- **Stiffness.** PETC models, especially under PAM protocols, are stiff — that's why this
+  project vendors Hairer's implicit Radau5 at all (ADR 0005, `mxlweb-core`:
+  vendored-hairer-solvers). The standard Neural-ODE continuous adjoint
+  ("`BacksolveAdjoint`" in SciMLSensitivity/diffrax terms — reconstruct the state
+  trajectory by re-integrating the forward vector field backward in time, alongside the
+  adjoint variable) is explicitly documented as unstable on stiff problems by both
+  ecosystems, independent of implementation quality: a forward-dissipative vector field
+  is an *expanding*, error-amplifying process when run backward, and that corrupts the
+  coupled adjoint variable regardless of its own dynamics.
+- **Opaque forward solver.** diffrax's own preferred default
+  (`RecursiveCheckpointAdjoint`, discretize-then-optimize) sidesteps that instability by
+  differentiating the solver's own step function directly — but that requires the step
+  function to be differentiable code. Ours isn't: Radau5/DOP853/DOPRI5 are opaque
+  compiled Fortran→C→Emscripten (`vendored-hairer-solvers`), not JAX. No JS/WASM ML
+  library changes this — a survey of jax-js, TensorFlow.js's WebGPU backend, and Burn's
+  WGPU+autodiff stack found none of them can differentiate through the vendored solver
+  either, because none can differentiate through opaque compiled machine code.
+
+The reframe that unblocks both constraints: the adjoint method doesn't require
+differentiating the *solver*, only computing vector-Jacobian products of the *RHS*. The
+RHS is already a `mathml` AST — a closed, finite set of node types (`Base`'s
+`Nullary`/`Unary`/`Binary`/`Nary` hierarchy, ~48 concrete classes across
+`mathml/{unary,unary-special,binary,nary}.ts`) evaluated through a shared visitor pattern
+(`Base.toWat`/`toJs`/`toPy`/`toTex`/`toSBML`/`toTs`/`toJson`). A VJP for that graph is one
+more visitor method, generated at compile time — no CAS, no `simplify()`/CSE step, no new
+dependency. And once NN blocks are just more node types in that same AST, "UDE" stops
+being a separate model class: a plain mechanistic model is simply the case where no NN
+node is present. Adjoint-based fitting is therefore useful beyond NN-augmented models —
+any model with many fitted mechanistic parameters benefits too, since `lmdif`'s
+finite-difference Jacobian cost scales with fitted-parameter count regardless of where
+those parameters came from.
+
+## 2. Decision
+
+### 2.1 Neural network blocks as new `mathml` AST node types
+
+A UDE correction term is authored as new node types alongside the existing
+`Nullary`/`Unary`/`Binary`/`Nary` hierarchy — an affine/dense node (weighted sum of named
+inputs plus bias) and activation nodes reusing (or extending, where absent) the existing
+`Unary` subclasses in `unary.ts` (`Tanh` etc.). Each participates in the same visitor
+pattern every other node already does; `wat-codegen.ts`'s `buildModelWat`/`buildDerivedWat`
+need no changes at all — NN nodes emit WAT like any other node. Exact node shapes are an
+open question (§4).
+
+### 2.2 Reverse-mode sensitivity as one more `Base` visitor method — no CAS required
+
+`Base` gains one more abstract method for backward/VJP accumulation, implemented once per
+concrete node class using that node's own known local derivative rule — the same two-pass
+graph walk PyTorch/JAX use internally (forward pass records values, one backward pass
+accumulates one adjoint per node in reverse topological order), not textual symbolic
+differentiation. Because the node-type set is closed and the graph has no control flow,
+mutation, or aliasing, this needs no simplifier or CSE pass and no CAS dependency — the
+same category of change `toWat` already was: one more thing every node type knows how to
+do.
+
+This must run live, in-browser: `ModelEditor.svelte` recompiles the AST at runtime on
+every edit, and `misc/mxl-codegen` (the offline Python pipeline, sibling `mxlpy`) only
+pre-generates initial model pages, not runtime edits — so there is no sympy/CAS shortcut
+available here even in principle. It does introduce a real constraint: derivative-graph
+codegen latency is now a live-UX cost on the edit-recompile loop, not a batch-job cost,
+most binding for large NN blocks (§4).
+
+### 2.3 Continuous adjoint, reusing the existing black-box solver for both passes
+
+Forward-solve as today, unmodified. For the backward pass, do **not** reconstruct y(t) by
+re-integrating the forward vector field backward in time (`BacksolveAdjoint` — see §1).
+Instead, obtain y(t) at whatever points the backward pass needs directly from the forward
+solve: Hairer's built-in dense-output/continuous-extension routines (`CONTR5`/`CONTD8`/
+`CONTD5`), or checkpointed accepted-step values with local interpolation as a fallback if
+dense output isn't currently exposed through the WASM bindings (open question, §4). Only
+the adjoint variable λ (plus a parameter-gradient quadrature accumulator) is
+backward-integrated. λ's ODE is linear given y(t) and inherits the *same* stiffness ratio
+as the forward problem (transposed, not worse) — it needs an implicit integrator too, but
+being linear, its per-step "Newton iteration" is a single linear solve, cheaper than the
+forward nonlinear one.
+
+This deliberately does not imitate diffrax's own preferred `RecursiveCheckpointAdjoint`:
+reaching into and differentiating Hairer's vendored Fortran step routines was considered
+and rejected as a categorically larger, higher-risk undertaking than interpolating a
+trajectory the solver already knows how to produce.
+
+### 2.4 Two fit backends, auto-selected once at `FIT_INIT` — invisible to the user
+
+`lmdif` (ADR 0004) remains the default, unchanged: for a handful of fitted mechanistic
+parameters its finite-difference Jacobian is cheap and its Gauss-Newton convergence beats
+a first-order method. It cannot scale to NN-sized parameter counts, though — not because
+its Jacobian estimate is inexact, but because it needs the full Jacobian of the *residual
+vector*, and reverse-mode/adjoint is only cheap for the *opposite* shape (gradient of one
+scalar loss, cost independent of parameter count). So a second backend is needed, not a
+drop-in replacement of `lmdif`'s Jacobian step: it runs the adjoint (§2.3) to get ∇_θL for
+the summed-residual loss each iteration, then takes a first-order optimizer step (exact
+algorithm: open question, §4).
+
+Backend choice is made once inside `fit_init`, before either backend's session state is
+allocated, and is never exposed as a user-facing setting — mxlweb's audience should never
+need to know an optimizer choice exists. `FitInitRequest` may carry an undocumented
+`backend?: FitBackend` override (not wired into `FitEditor.svelte`) strictly for tests and
+debugging. The trigger is a measured cost estimate, not a purely structural one:
+`FIT_INIT` already performs one forward solve to compute `initialResidualNorm` (ADR 0004
+§2.11); that measured wall-clock cost, multiplied by `fitIdx.length`, is compared against a
+time budget. This captures stiffness-driven cost directly — a slow PETC/PAM solve trips
+the switch sooner even with few NN weights — which a purely structural proxy like
+`#reactions × #fittedParams` cannot. Exact threshold: open question, §4.
+
+### 2.5 Backend-agnostic stopping criteria and progress reporting
+
+Both backends report through one shape, so `fitStore.ts`/`FitEditor.svelte` never need to
+know which one ran:
+
+```ts
+export type FitBackend = "lm" | "adjoint";
+
+export type FitStopReason =
+  | "converged_residual"
+  | "converged_gradient"
+  | "converged_step"
+  | "plateau"
+  | "target_reached"
+  | "budget_reached"
+  | "error";
+
+export interface FitStoppingCriteria {
+  /** Renamed from `maxfev` (ADR 0004). Unit is backend-specific: function
+   * evaluations under "lm", optimizer steps under "adjoint". */
+  maxIterations: number;
+  /** Shared, unchanged semantics from ADR 0004 §2.7/2.11. */
+  targetResidualNorm?: number;
+  /** "adjoint" only — ignored (or rejected at FIT_INIT) under "lm". */
+  gradNormTol?: number;
+  /** "adjoint" only. */
+  plateau?: { patience: number; minDelta: number };
+}
+
+export interface FitProgress {
+  requestId: string;
+  backend: FitBackend;
+  nfev: number;
+  residualNorm: number;
+  /** "adjoint" only; absent under "lm". */
+  gradNorm?: number;
+  params: number[];
+  done: boolean;
+  reason?: FitStopReason; // present iff done
+  err?: SimulationError;
+}
+```
+
+`lmdif`'s raw `info` code is not surfaced to callers — it maps onto `FitStopReason` inside
+`fitWorker.ts`:
+
+| `info`  | MINPACK meaning                                     | `FitStopReason`     |
+| ------- | ---------------------------------------------------- | -------------------- |
+| 1, 3    | relative reduction in sum-of-squares below `ftol`     | `converged_residual` |
+| 2       | relative change in solution below `xtol`              | `converged_step`     |
+| 4, 8    | residuals orthogonal to Jacobian columns (`gtol`) — already a first-order-optimality / gradient-based check | `converged_gradient` |
+| 6, 7    | `ftol`/`xtol` too small to improve further — already a "stopped improving" signal | `plateau`             |
+| 5       | `maxfev` (now `maxIterations`) exhausted              | `budget_reached`     |
+| custom `-2` | `targetResidualNorm` crossed (ADR 0004 §2.7, unchanged) | `target_reached` |
+| 0, other negative | bad input / genuine failure                 | `error`               |
+
+`converged_step` has no "adjoint" equivalent and is never emitted on that path — a
+first-order optimizer's step size reflects its learning-rate schedule, not proximity to a
+solution; `plateau` already covers the practical "stopped improving" need.
+
+## 3. Rationale
+
+Every piece reuses an existing pattern rather than introducing a new one: the AST's
+generic per-node visitor methods (§2.1, §2.2), the existing chunked
+`FIT_INIT`/`FIT_CHUNK`/`FIT_FREE` worker protocol and its `initialResidualNorm` probe
+(§2.4), and ADR 0004's fit-target/data plumbing, none of which need to change shape. The
+one deliberate departure from prior art is *not* following diffrax's own preferred
+adjoint strategy (§2.3) — the reason is architectural (opaque solver), not a disagreement
+with that recommendation.
+
+## 4. Consequences / Open Questions
+
+- Exact new node types and their backward rules (dense/affine node shape, which
+  activations beyond what `unary.ts` already has) — not yet designed.
+- Optimizer for the "adjoint" backend (Adam vs. L-BFGS) and its hyperparameters — not yet
+  decided.
+- Exact auto-selection time-budget threshold (§2.4) — not yet calibrated; needs
+  benchmarking against real PETC/PAM models, not guessed.
+- Whether Hairer's dense-output routines are already reachable through the current WASM
+  bindings, or need new exposure — not yet checked.
+- How the augmented adjoint state (λ plus the quadrature accumulator) is wired into a new
+  C-side integration path alongside `radau5_wrapper.c` — not yet designed.
+- Codegen latency for the backward graph on live `ModelEditor.svelte` edits is a real UX
+  risk for large NN blocks — not yet benchmarked.
+- Implementation spans both repos, per ADR 0004's precedent; the backend-agnostic types in
+  §2.5 are the only piece of this ADR specified precisely enough to implement without
+  further design work.

--- a/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
+++ b/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
@@ -1,4 +1,4 @@
-# ADR 0005: Neural Network Corrections via AST Nodes, and Adjoint-Based Fitting
+# ADR 0005: Neural Network Corrections as Generated Model Terms, and Adjoint-Based Fitting
 
 **Status:** Proposed
 **Scope:** `ModelEditor` (this repo); `mathml/`, `src-c/`, `backends/wasm/` (sibling
@@ -43,24 +43,78 @@ RHS is already a `mathml` AST — a closed, finite set of node types (`Base`'s
 `mathml/{unary,unary-special,binary,nary}.ts`) evaluated through a shared visitor pattern
 (`Base.toWat`/`toJs`/`toPy`/`toTex`/`toSBML`/`toTs`/`toJson`). A VJP for that graph is one
 more visitor method, generated at compile time — no CAS, no `simplify()`/CSE step, no new
-dependency. And once NN blocks are just more node types in that same AST, "UDE" stops
-being a separate model class: a plain mechanistic model is simply the case where no NN
-node is present. Adjoint-based fitting is therefore useful beyond NN-augmented models —
+dependency. And once an NN correction term is just an *instance* of that same AST built
+from existing node types (§2.1) rather than a distinct kind of thing, "UDE" stops being a
+separate model class: a plain mechanistic model is simply the case where no generated NN
+term is present. Adjoint-based fitting is therefore useful beyond NN-augmented models —
 any model with many fitted mechanistic parameters benefits too, since `lmdif`'s
 finite-difference Jacobian cost scales with fitted-parameter count regardless of where
 those parameters came from.
 
 ## 2. Decision
 
-### 2.1 Neural network blocks as new `mathml` AST node types
+### 2.1 Neural network blocks as *generated* expressions — zero new `mathml` node types
 
-A UDE correction term is authored as new node types alongside the existing
-`Nullary`/`Unary`/`Binary`/`Nary` hierarchy — an affine/dense node (weighted sum of named
-inputs plus bias) and activation nodes reusing (or extending, where absent) the existing
-`Unary` subclasses in `unary.ts` (`Tanh` etc.). Each participates in the same visitor
-pattern every other node already does; `wat-codegen.ts`'s `buildModelWat`/`buildDerivedWat`
-need no changes at all — NN nodes emit WAT like any other node. Exact node shapes are an
-open question (§4).
+A UDE correction term needs **no new `mathml` node types at all**. `KineticModelBuilder`
+already establishes the precedent: `Reaction` isn't its own AST node — `reactionTerm()`
+(`kineticModelBuilder.ts`) builds each dx/dt contribution as literal `new Mul([new
+Num(coeff), new Name(rxnName)])` instances, summed via `new Add(terms)`, using the
+existing `Mul`/`Add`/`Num`/`Name` classes. An NN block follows the same shape: an affine
+combination is `Add` of `Mul(Name(weight), Name(input))` terms plus a bias `Name`, wrapped
+in an activation node that — per §2.1.1 below — is *also* built from existing primitives.
+The whole block is an ordinary, if larger, expression tree indistinguishable from any
+hand-written rate law once generated. Consequently, §2.2's per-node backward rule only
+ever needs to cover the ~48 node types that already exist — there is no NN-specific
+differentiation code to write, ever; a generated block differentiates correctly for the
+same reason it evaluates correctly, because nothing downstream can tell it apart from a
+hand-authored expression.
+
+Concretely, a `KineticModelBuilder`-side generator function (mirroring `reactionTerm()`'s
+shape) takes an architecture spec (n inputs → h hidden units → m outputs) and produces (a)
+new `Parameter` entries for every weight and bias and (b) the nested expression per output
+— generated once when the block is authored or resized, never hand-typed.
+
+**This generator is builder-agnostic and must be, since it isn't only consumed by
+`KineticModelBuilder`.** `OdeModelBuilder` (`odeModelBuilder.ts`) has no reactions or
+stoichiometry concept whatsoever — `setDifferential(key, fn: Base)` sets each variable's
+dx/dt directly as a plain `Base` expression, and the two builders only converge downstream
+("lower into the same shared IR," per that file's own doc comment). The generator's output
+— a `Base` expression plus a set of `Parameter` entries — is the same regardless of
+builder; only how it's wired in differs, and both wiring points already exist with no new
+concept needed:
+
+- **`KineticModelBuilder`**: the generated expression becomes an ordinary reaction's `fn`,
+  with stoichiometry `{ variable: 1 }` — a UDE correction term *is* a reaction whose rate
+  law happens to be machine-generated instead of hand-typed. Nothing about the
+  reaction/stoichiometry abstraction changes.
+- **`OdeModelBuilder`**: the generated expression is added into the existing differential —
+  `setDifferential(key, new Add([currentExpr, nnBlockExpr]))` — again just composition
+  with what's already there.
+
+#### 2.1.1 Activation: softplus, in its numerically-stable form — still no new node type
+
+Softplus is the default activation for both UDE correction terms and full NODEs (not
+tanh — tanh was this ADR's original placeholder default, superseded by this decision).
+Like tanh, softplus is smooth (C^∞), which matters here more than in ordinary deep
+learning: a kink in the vector field (ReLU's, most obviously) gives Radau5/DOP853's
+adaptive step-size control a hidden quasi-event to repeatedly shrink around, and violates
+the smoothness the adjoint method's own derivation assumes — ReLU is not offered as an
+option for this reason. `softplus(x) = ln(1 + exp(x))` is expressible entirely with
+existing nodes (`Ln`, `Exp`, `Add`, `Num`) — but generate its numerically-stable form,
+`max(x, 0) + ln(1 + exp(-|x|))` (`Max`, `Abs`, `Add`, `Exp`, `Ln`, `Minus`, all existing),
+not the naive one: naive `ln(1+exp(x))` overflows to `Infinity` for large `x` instead of
+the correct asymptotic value of `x` itself, and a single `Infinity`/`NaN` mid-solve during
+a fit corrupts the whole trajectory (see ADR 0004 §2.8's large-finite-penalty handling for
+what this is otherwise mistaken for).
+
+#### 2.1.2 A generated weight must not default to log-space fitting
+
+ADR 0004 §2.4's fit-parameter default is log-space, "since... virtually every fittable
+parameter... must stay positive." That default is wrong for NN weights and biases, which
+must range over all reals to represent anything nontrivial. The generator must set ADR
+0004's existing per-parameter "fit in linear space" toggle for every weight/bias it
+creates — this needs to happen at generation time, not left as a trap for whoever wires
+generated parameters into the existing fit-parameter table.
 
 ### 2.2 Reverse-mode sensitivity as one more `Base` visitor method — no CAS required
 
@@ -184,18 +238,26 @@ solution; `plateau` already covers the practical "stopped improving" need.
 
 ## 3. Rationale
 
-Every piece reuses an existing pattern rather than introducing a new one: the AST's
-generic per-node visitor methods (§2.1, §2.2), the existing chunked
+Every piece reuses an existing pattern rather than introducing a new one: `reactionTerm()`'s
+generated-expression shape and the reaction/stoichiometry and `setDifferential` wiring
+points (§2.1), the AST's generic per-node visitor methods (§2.2), the existing chunked
 `FIT_INIT`/`FIT_CHUNK`/`FIT_FREE` worker protocol and its `initialResidualNorm` probe
-(§2.4), and ADR 0004's fit-target/data plumbing, none of which need to change shape. The
-one deliberate departure from prior art is *not* following diffrax's own preferred
-adjoint strategy (§2.3) — the reason is architectural (opaque solver), not a disagreement
-with that recommendation.
+(§2.4), and ADR 0004's fit-target/data plumbing (including its per-parameter linear-space
+toggle, reused rather than replaced in §2.1.2), none of which need to change shape. The one
+deliberate departure from prior art is *not* following diffrax's own preferred adjoint
+strategy (§2.3) — the reason is architectural (opaque solver), not a disagreement with
+that recommendation.
 
 ## 4. Consequences / Open Questions
 
-- Exact new node types and their backward rules (dense/affine node shape, which
-  activations beyond what `unary.ts` already has) — not yet designed.
+- Backward rules for the ~48 existing node types (§2.2) — not yet designed; this is the
+  actual remaining differentiation work, since §2.1 needs no NN-specific rules.
+- NN block architecture limits for v1 — single hidden layer only, or deeper? Affects both
+  generated-expression size (codegen latency, §2.2) and how many new `Parameter` rows the
+  generator dumps into `ModelEditor`'s parameter table per block. Not yet decided.
+- How a generated NN block's parameters are presented/grouped in `ModelEditor`'s parameter
+  table — one row per weight (could be dozens per block) vs. some collapsed group view —
+  not yet designed.
 - Optimizer for the "adjoint" backend (Adam vs. L-BFGS) and its hyperparameters — not yet
   decided.
 - Exact auto-selection time-budget threshold (§2.4) — not yet calibrated; needs

--- a/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
+++ b/docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md
@@ -70,9 +70,18 @@ same reason it evaluates correctly, because nothing downstream can tell it apart
 hand-authored expression.
 
 Concretely, a `KineticModelBuilder`-side generator function (mirroring `reactionTerm()`'s
-shape) takes an architecture spec (n inputs → h hidden units → m outputs) and produces (a)
-new `Parameter` entries for every weight and bias and (b) the nested expression per output
-— generated once when the block is authored or resized, never hand-typed.
+shape) takes an architecture spec (n inputs → depth × width hidden layers → m outputs) and
+produces (a) new `Parameter` entries for every weight and bias and (b) the nested
+expression per output — generated once when the block is authored or resized, never
+hand-typed.
+
+**Depth is arbitrary/configurable from v1, not capped at one hidden layer.** A single
+hidden layer is theoretically sufficient (the universal approximation theorem is stated for
+exactly that case), but real prior work in this problem domain needed more: 3 layers deep
+in `2026-ps-model-comp`, 6 layers deep (`flux_width=64`) in `2026-chilling-nights`. Capping
+v1 at one layer would make it unable to reproduce work already done. A block at that scale
+(6 × 64 ≈ 20,800 parameters) is exactly the regime §2.1.3 and §2.4 are designed around —
+this is not a hypothetical edge case.
 
 **This generator is builder-agnostic and must be, since it isn't only consumed by
 `KineticModelBuilder`.** `OdeModelBuilder` (`odeModelBuilder.ts`) has no reactions or
@@ -116,6 +125,21 @@ must range over all reals to represent anything nontrivial. The generator must s
 creates — this needs to happen at generation time, not left as a trap for whoever wires
 generated parameters into the existing fit-parameter table.
 
+#### 2.1.3 Weights are a separate concept from parameters — never individual table rows
+
+ADR 0004 §2.4's parameter table is built around a human looking at and hand-tuning each
+row: current value doubles as initial guess, one fit checkbox per row. That model doesn't
+survive a 6×64 block's ≈20,800 weights. NN weights and ODE parameters are kept as
+deliberately separate concepts: a block is authored/resized as one unit in its own UI
+(architecture spec, which variable/reaction it corrects), never expanded into individual
+rows in `ModelEditor`'s existing parameter table. Weights are seeded via standard
+randomized init (Xavier/Glorot-style) and from then on change *only* through fitting —
+never hand-edited. Fitting itself becomes a **per-block toggle** ("train this block: yes/
+no"), not per-weight checkboxes; there's no real scenario where half a block's weights
+should be frozen while the rest train. This also makes §2.1.2's log-space trap purely an
+internal-representation correctness question rather than a UX-surfacing one, since a weight
+is never visible through the UI path that default applies to.
+
 ### 2.2 Reverse-mode sensitivity as one more `Base` visitor method — no CAS required
 
 `Base` gains one more abstract method for backward/VJP accumulation, implemented once per
@@ -130,19 +154,54 @@ do.
 This must run live, in-browser: `ModelEditor.svelte` recompiles the AST at runtime on
 every edit, and `misc/mxl-codegen` (the offline Python pipeline, sibling `mxlpy`) only
 pre-generates initial model pages, not runtime edits — so there is no sympy/CAS shortcut
-available here even in principle. It does introduce a real constraint: derivative-graph
-codegen latency is now a live-UX cost on the edit-recompile loop, not a batch-job cost,
-most binding for large NN blocks (§4).
+available here even in principle. This is substantially less of a live-UX risk than it
+first appears, though: `buildModelWat`'s signature (`equations`, `varNames`, `parNames`)
+depends only on model *structure* — values (including weight values during fitting) flow
+in separately at runtime via `y_ptr`/`rpar_ptr`, never baked into the compiled WAT. Both
+the forward and backward codegen passes therefore only re-run on structural edits (adding a
+reaction, resizing an NN block), never on value edits (a fit iteration, dragging a
+parameter slider) — the cost of differentiating a large block is paid once per deliberate
+architecture decision, not per fit-iteration or per keystroke.
+
+#### 2.2.1 Non-smooth node types: zero gradient by convention, documented at each site
+
+Most of the ~48 node types are ordinary calculus (`Exp' = Exp`, `Sin' = Cos`, ...) with no
+design decision to make. The exceptions:
+
+- **`Floor`/`Ceiling`**: piecewise-constant, so the honest derivative is `0` almost
+  everywhere (undefined exactly at integer boundaries — measure zero). Implemented as
+  literal zero, the same convention every AD system uses. Consequence worth documenting
+  loudly at the implementation site, not just here: if a fitted parameter's only path to
+  the loss runs through one of these, Adam sees zero gradient and that parameter simply
+  won't move — correct behavior, but easy to mistake for a bug without a comment explaining
+  it.
+- **Comparison/boolean nodes** (`Eq`, `GreaterThan`, `And`, etc.): same reasoning, same
+  convention — a truth value doesn't vary smoothly with its operands. In practice these are
+  almost always a `Piecewise` condition, not a value flowing further into arithmetic.
+- **`Factorial`**: a proper derivative needs the digamma function, which isn't among the
+  existing WAT math imports (`exp`/`log`/`sin`/`...`/`pow`/`max`/`min`/`rem` — no digamma).
+  Declined to add it: `Factorial` is never emitted by the NN-block generator and is rare in
+  hand-written kinetic rate laws, so it isn't worth expanding the primitive math surface
+  for. Treated as gradient-zero, same as the discrete nodes above.
+- **`Piecewise`/`Max`/`Min`**: not actually a problem, despite not being smooth at their
+  branch/tie boundaries — route the adjoint only into whichever branch or argument was
+  actually selected during the forward pass (the standard `lax.cond`/`jnp.where`-style
+  rule). Zero into every branch not taken.
+- **`RateOf`**: needs no rule at all — it's already a literal zero stub in every numeric
+  backend (`toJs`/`toPy`/`toWat` all emit `"0"`; only `toTex`/`toSBML` render it
+  meaningfully, for SBML-roundtrip display), an artifact of importing SBML's `rateOf`
+  csymbol into a system that only solves explicit ODEs. Its backward rule is trivially
+  zero, consistent with the rest of it.
+
+Every zero-emitting rule above must carry an explicit code comment stating *why* it's zero
+— a documented convention, not a silent stub that reads as an oversight.
 
 ### 2.3 Continuous adjoint, reusing the existing black-box solver for both passes
 
 Forward-solve as today, unmodified. For the backward pass, do **not** reconstruct y(t) by
 re-integrating the forward vector field backward in time (`BacksolveAdjoint` — see §1).
 Instead, obtain y(t) at whatever points the backward pass needs directly from the forward
-solve: Hairer's built-in dense-output/continuous-extension routines (`CONTR5`/`CONTD8`/
-`CONTD5`), or checkpointed accepted-step values with local interpolation as a fallback if
-dense output isn't currently exposed through the WASM bindings (open question, §4). Only
-the adjoint variable λ (plus a parameter-gradient quadrature accumulator) is
+solve. Only the adjoint variable λ (plus a parameter-gradient quadrature accumulator) is
 backward-integrated. λ's ODE is linear given y(t) and inherits the *same* stiffness ratio
 as the forward problem (transposed, not worse) — it needs an implicit integrator too, but
 being linear, its per-step "Newton iteration" is a single linear solve, cheaper than the
@@ -153,6 +212,61 @@ reaching into and differentiating Hairer's vendored Fortran step routines was co
 and rejected as a categorically larger, higher-risk undertaking than interpolating a
 trajectory the solver already knows how to produce.
 
+#### 2.3.1 Getting y(t): checkpoint + local Hermite interpolation, not Hairer's dense output
+
+Checked, not assumed: real dense output is **not** currently reachable. All three wrappers
+(`radau5_wrapper.c`) call their solver with `IOUT = 1` (Hairer's "call `solout` every
+accepted step, but skip computing the dense-output polynomial" mode). `contr5_`/`contd8_`/
+`contd5_` exist in the vendored source but their `CONT` coefficient arrays are never
+populated in this mode — ADR 0004 §2.6's "already produce dense output" meant "produce
+enough step points for linear interpolation to look smooth," not Hairer's literal
+continuous extension.
+
+Two ways to get real y(t) at the backward pass's query points: (A) flip `IOUT` to 2,
+store the `CONT` array per step, export the `contr5_`/`contd8_`/`contd5_` query functions
+— higher accuracy, matching each solver's own order, but reaches into Hairer's vendored
+solver-driver internals in three places and grows memory per step (a coefficient array, not
+two numbers); or (B) reuse the `(t, y)` checkpoint data **already collected today** for
+chart plotting (`_get_out_t`/`_get_out_y`) and do local cubic Hermite interpolation within
+the bracketing step, using `y` and `f = dy/dt` at both endpoints (one extra RHS evaluation
+per endpoint, already have the RHS) — third-order accurate, zero changes to the vendored
+solver-driver code.
+
+**Decision: B.** This ADR already rejects reaching into Hairer's vendored internals once,
+for exactly this reason (§2.3's `RecursiveCheckpointAdjoint` rejection) — option A would
+quietly break that same principle for a secondary accuracy gain. Revisit only if B's
+accuracy is a measured problem later, not a theoretical one. A direct consequence: **the
+forward pass needs zero C changes** — `run_radau5`/`_get_out_t`/`_get_out_y` already
+produce exactly the checkpoint data B needs.
+
+#### 2.3.2 Backward integrator: reuse whichever solver ran forward
+
+No separate backend-solver choice — the backward pass uses whichever of
+radau5/dop853/dopri5 `FitInitRequest.solver` already selected. Stiffness is a property of
+the system, not of which method was picked: if the forward pass needed Radau5's implicit
+solve, the backward adjoint ODE (same eigenvalue structure, transposed) needs it too; if
+dop853 sufficed forward, it suffices backward.
+
+#### 2.3.3 New C entry points, not an extension of `fit_init`/`fit_chunk`
+
+The adjoint backend gets its own `adjoint_init`/`adjoint_chunk`/`adjoint_free`, dispatched
+from `fitWorker.ts` on `session.backend` (already exists per §2.4), rather than growing
+`fit_init`/`fit_chunk` in place. `fit_init`'s current signature (`y0, pars, fitIdx,
+logFlags, targets, dataT, dataY, tEnd, nDerived, solver, rtol, atol, targetResidualNorm`)
+has no room for `gradNormTol`/`plateau`, and shares essentially no algorithm with an
+ODE-based backward integration — MINPACK's QR/trust-region machinery and Adam-on-an-
+augmented-adjoint-ODE have nothing in common to factor out.
+
+#### 2.3.4 The backward/VJP WAT is generated lazily — only when actually needed
+
+Mirrors an existing pattern rather than inventing one: `FitInitRequest.derivedWat` is
+already optional, generated by the caller only when some fit target needs a derived
+quantity — the WASM side never computes it otherwise. The backward graph does the same:
+a new `FitInitRequest.adjointWat?: string`, generated by a new backward-codegen method on
+`KineticModelBuilder`/`OdeModelBuilder`, called by `mxl-web` **only** when it's about to
+request `backend: "adjoint"`. Plain simulation (`wasmWorker.ts`) never touches it, and
+neither does an `"lm"` fit, which has no use for analytic derivatives at all.
+
 ### 2.4 Two fit backends, auto-selected once at `FIT_INIT` — invisible to the user
 
 `lmdif` (ADR 0004) remains the default, unchanged: for a handful of fitted mechanistic
@@ -162,19 +276,34 @@ its Jacobian estimate is inexact, but because it needs the full Jacobian of the 
 vector*, and reverse-mode/adjoint is only cheap for the *opposite* shape (gradient of one
 scalar loss, cost independent of parameter count). So a second backend is needed, not a
 drop-in replacement of `lmdif`'s Jacobian step: it runs the adjoint (§2.3) to get ∇_θL for
-the summed-residual loss each iteration, then takes a first-order optimizer step (exact
-algorithm: open question, §4).
+the summed-residual loss each iteration, then takes an **Adam** step (learning rate
+`1e-4`, matching prior real usage across adam/adamw/adabelief in this problem domain — v1
+ships plain Adam only, the others deferred). L-BFGS was considered and rejected outright,
+not just deprioritized: its line-search-driven, full-batch quasi-Newton approach assumes a
+smoother, more locally-quadratic loss surface than deep, non-convex ODE/UDE landscapes
+actually have — the same reason Adam-family optimizers displaced L-BFGS for NN training
+generally, reinforced here by direct prior experience with these specific loss landscapes,
+not just general folklore.
 
 Backend choice is made once inside `fit_init`, before either backend's session state is
 allocated, and is never exposed as a user-facing setting — mxlweb's audience should never
 need to know an optimizer choice exists. `FitInitRequest` may carry an undocumented
 `backend?: FitBackend` override (not wired into `FitEditor.svelte`) strictly for tests and
-debugging. The trigger is a measured cost estimate, not a purely structural one:
-`FIT_INIT` already performs one forward solve to compute `initialResidualNorm` (ADR 0004
-§2.11); that measured wall-clock cost, multiplied by `fitIdx.length`, is compared against a
-time budget. This captures stiffness-driven cost directly — a slow PETC/PAM solve trips
-the switch sooner even with few NN weights — which a purely structural proxy like
-`#reactions × #fittedParams` cannot. Exact threshold: open question, §4.
+debugging.
+
+The trigger simplifies given §2.1.3's per-block toggle: **any active NN block forces
+`"adjoint"` unconditionally** — no cost computation needed, since a 6×64 block's ≈20,800
+finite-difference forward solves are obviously intractable regardless of measured per-solve
+cost. The measured-cost heuristic is only needed for the narrower case it was always
+better suited to: a purely mechanistic model with many fitted kinetic parameters and no NN
+block at all. There, `FIT_INIT` already performs one forward solve to compute
+`initialResidualNorm` (ADR 0004 §2.11); that measured wall-clock cost, multiplied by
+`fitIdx.length`, is compared against a time budget — capturing stiffness-driven cost
+directly (a slow PETC/PAM solve trips the switch sooner even with few fitted parameters),
+which a purely structural proxy like `#reactions × #fittedParams` cannot. The exact budget
+number is deliberately left uncalibrated — not something to responsibly guess without
+benchmarking against real models; start with a conservative placeholder (e.g. 200ms) and
+tune once real models exist to measure against.
 
 ### 2.5 Backend-agnostic stopping criteria and progress reporting
 
@@ -250,24 +379,22 @@ that recommendation.
 
 ## 4. Consequences / Open Questions
 
-- Backward rules for the ~48 existing node types (§2.2) — not yet designed; this is the
-  actual remaining differentiation work, since §2.1 needs no NN-specific rules.
-- NN block architecture limits for v1 — single hidden layer only, or deeper? Affects both
-  generated-expression size (codegen latency, §2.2) and how many new `Parameter` rows the
-  generator dumps into `ModelEditor`'s parameter table per block. Not yet decided.
-- How a generated NN block's parameters are presented/grouped in `ModelEditor`'s parameter
-  table — one row per weight (could be dozens per block) vs. some collapsed group view —
-  not yet designed.
-- Optimizer for the "adjoint" backend (Adam vs. L-BFGS) and its hyperparameters — not yet
-  decided.
-- Exact auto-selection time-budget threshold (§2.4) — not yet calibrated; needs
-  benchmarking against real PETC/PAM models, not guessed.
-- Whether Hairer's dense-output routines are already reachable through the current WASM
-  bindings, or need new exposure — not yet checked.
-- How the augmented adjoint state (λ plus the quadrature accumulator) is wired into a new
-  C-side integration path alongside `radau5_wrapper.c` — not yet designed.
-- Codegen latency for the backward graph on live `ModelEditor.svelte` edits is a real UX
-  risk for large NN blocks — not yet benchmarked.
-- Implementation spans both repos, per ADR 0004's precedent; the backend-agnostic types in
-  §2.5 are the only piece of this ADR specified precisely enough to implement without
-  further design work.
+Every major branch of this design is now resolved (§2.1–§2.5, via a dedicated design
+session — see the ADR history for what was reconsidered along the way, e.g. the original
+"new AST node types" and "single hidden layer" framings, both superseded). What remains is
+implementation, plus two things that are deliberately *not* design decisions to make from
+first principles:
+
+- The exact auto-selection time-budget threshold (§2.4) — a placeholder (200ms) ships
+  first; the real number needs calibration against real PETC/PAM models, not a guess.
+- Whether local Hermite interpolation's accuracy (§2.3.1, option B) is ever actually a
+  problem in practice — revisit toward Hairer's true dense output (option A) only if
+  measured, not preemptively.
+- Implementation spans both repos, per ADR 0004's precedent. Suggested order: (1) the
+  per-node backward/VJP rule (§2.2, §2.2.1) — foundational, self-contained, testable against
+  finite differences in isolation; (2) the NN-block generator (§2.1) — pure AST generation
+  using node types that already codegen correctly; (3) the graph-level backward-WAT
+  orchestration tying (1) into a full model (topological walk, intermediate-sharing scheme
+  — not yet designed at that level of detail, deliberately deferred past this ADR); (4) the
+  C-side adjoint entry points and Hermite interpolation (§2.3.1–§2.3.4); (5) `ModelEditor`
+  UI for authoring/toggling blocks (§2.1.3).

--- a/docs/adrs/CONTEXT.md
+++ b/docs/adrs/CONTEXT.md
@@ -27,13 +27,14 @@ Spans this repo and `mxlweb-core`: fitting reuses the WASM backend's in-WASM
 function-pointer pattern (vendoring `cminpack`'s `lmdif` alongside the existing
 Radau5/DOP853/DOPRI5 build) rather than adding a JS-side optimization library.
 
-→ [ADR 0005 — Neural network corrections via AST nodes, and adjoint-based fitting](0005-neural-network-corrections-and-adjoint-fitting.md)
+→ [ADR 0005 — Neural network corrections as generated model terms, and adjoint-based fitting](0005-neural-network-corrections-and-adjoint-fitting.md)
 
-Spans this repo and `mxlweb-core`: makes every model a potential UDE by adding neural
-network blocks as ordinary `mathml` AST nodes, adds a continuous-adjoint sensitivity
-backend (reusing the existing solver for both passes, avoiding the backsolve instability
-on stiff PETC/PAM models) alongside `lmdif`, and generalizes ADR 0004's fit stopping
-criteria/progress reporting to be backend-agnostic.
+Spans this repo and `mxlweb-core`: makes every model a potential UDE by generating neural
+network blocks as ordinary expressions from existing `mathml` node types (no new AST
+surface — same trick `KineticModelBuilder`'s reactions already use), adds a
+continuous-adjoint sensitivity backend (reusing the existing solver for both passes,
+avoiding the backsolve instability on stiff PETC/PAM models) alongside `lmdif`, and
+generalizes ADR 0004's fit stopping criteria/progress reporting to be backend-agnostic.
 
 ## Inherited from mxlweb-core
 

--- a/docs/adrs/CONTEXT.md
+++ b/docs/adrs/CONTEXT.md
@@ -27,6 +27,14 @@ Spans this repo and `mxlweb-core`: fitting reuses the WASM backend's in-WASM
 function-pointer pattern (vendoring `cminpack`'s `lmdif` alongside the existing
 Radau5/DOP853/DOPRI5 build) rather than adding a JS-side optimization library.
 
+→ [ADR 0005 — Neural network corrections via AST nodes, and adjoint-based fitting](0005-neural-network-corrections-and-adjoint-fitting.md)
+
+Spans this repo and `mxlweb-core`: makes every model a potential UDE by adding neural
+network blocks as ordinary `mathml` AST nodes, adds a continuous-adjoint sensitivity
+backend (reusing the existing solver for both passes, avoiding the backsolve instability
+on stiff PETC/PAM models) alongside `lmdif`, and generalizes ADR 0004's fit stopping
+criteria/progress reporting to be backend-agnostic.
+
 ## Inherited from mxlweb-core
 
 This site does not re-decide: the no-server/all-client-side stance, the three compute

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
     },
     "node_modules/@computational-biology-aachen/mxlweb-core": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Computational-Biology-Aachen/mxlweb-core.git#45ced7cd0ff93d7193c91b2f69244cb9b0828f23",
-      "integrity": "sha512-yQrPnuRtzuKDYnOfqqOv/eUVbcNF2cGhbSy08KmMoY6X2kpFh7V4L9JBxJzSxsY7uYWDF5R7PvEdbMl8MejJjw==",
+      "resolved": "git+ssh://git@github.com/Computational-Biology-Aachen/mxlweb-core.git#ed65dac4a56c48c6689cae23e2379462ef87a630",
+      "integrity": "sha512-0FxekI4leh1sxmhQiozk+HGjhuQG4bR9wcxppp2VYTZOF5krF4VcpLxy9Fn8POb27/nG6NgtY2ovIxa9U7Lfpg==",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/src/lib/AnalysesDashboard.svelte
+++ b/src/lib/AnalysesDashboard.svelte
@@ -280,7 +280,12 @@
   }
 
   function addParameterScan(box: Box) {
-    const firstParam = model.parameters.keys().next().value ?? "";
+    // Skip NN-block-owned weights/biases (ADR 0005 §2.1.3) — otherwise a
+    // model with a trained block could default to a scan target that
+    // ParameterScanEditor's own dropdown then excludes as an option.
+    const owned = model.nnBlockOwnedParameterNames();
+    const firstParam =
+      model.parameters.keys().find((k) => !owned.has(k)) ?? "";
     const newScan: ParameterScanAnalysis = {
       type: "parameterScan",
       id: box.id,

--- a/src/lib/AnalysesDashboard.svelte
+++ b/src/lib/AnalysesDashboard.svelte
@@ -138,6 +138,10 @@
 
   let fileInput = $state<HTMLInputElement | null>(null);
   let loadError = $state<string | null>(null);
+  // SBML/MxlPy export both throw for a model with any NN block (neither
+  // format can represent one) -- surfaced here rather than left as an
+  // uncaught exception the export button's onclick would otherwise produce.
+  let exportError = $state<string | null>(null);
   let pendingBox = $state<Box | null>(null);
   let pickerEl = $state<HTMLDivElement | null | undefined>(null);
   let analysisEditorEls = $state<
@@ -157,11 +161,16 @@
   function saveModel() {
     // SBML is a reaction-network format; only kinetic models can be exported.
     if (!(model instanceof KineticModelBuilder)) return;
-    downloadText(
-      modelToSbml(model, name),
-      `${name.replace(/[^A-Za-z0-9]/g, "_")}.sbml`,
-      "application/xml",
-    );
+    exportError = null;
+    try {
+      downloadText(
+        modelToSbml(model, name),
+        `${name.replace(/[^A-Za-z0-9]/g, "_")}.sbml`,
+        "application/xml",
+      );
+    } catch (e) {
+      exportError = e instanceof Error ? e.message : "Failed to export SBML";
+    }
   }
 
   function savePython() {
@@ -174,11 +183,16 @@
 
   function saveMxlpy() {
     if (!(model instanceof KineticModelBuilder)) return;
-    downloadText(
-      model.buildMxlpy(),
-      `${name.replace(/[^A-Za-z0-9]/g, "_")}.py`,
-      "text/x-python",
-    );
+    exportError = null;
+    try {
+      downloadText(
+        model.buildMxlpy(),
+        `${name.replace(/[^A-Za-z0-9]/g, "_")}.py`,
+        "text/x-python",
+      );
+    } catch (e) {
+      exportError = e instanceof Error ? e.message : "Failed to export MxlPy";
+    }
   }
 
   function saveMxlweb() {
@@ -385,6 +399,9 @@
   />
   {#if loadError}
     <p class="load-error">{loadError}</p>
+  {/if}
+  {#if exportError}
+    <p class="load-error">{exportError}</p>
   {/if}
   {#if children}
     {@render children()}

--- a/src/lib/AnalysesDashboard.svelte
+++ b/src/lib/AnalysesDashboard.svelte
@@ -97,9 +97,13 @@
   }
 
   let parSliders = $derived.by(() => {
+    // NN block weights/biases must never surface as sliders (ADR 0005
+    // §2.1.3) — the generator itself never sets `.slider`, so this only
+    // matters defensively against a loaded .mxl.json with a hand-set one.
+    const owned = model.nnBlockOwnedParameterNames();
     return model.parameters
       .entries()
-      .filter((k) => k[1].slider !== undefined)
+      .filter((k) => k[1].slider !== undefined && !owned.has(k[0]))
       .map(([id, par]) => {
         return {
           id: id,

--- a/src/lib/EqEditor.svelte
+++ b/src/lib/EqEditor.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import EqNode from "$lib/EqNode.svelte";
   import { Button, Math, Row } from "@computational-biology-aachen/design";
-  import { defaultValue } from "@computational-biology-aachen/mxlweb-core";
+  import {
+    defaultValue,
+    isNNBlockOwnedParamName,
+  } from "@computational-biology-aachen/mxlweb-core";
   import {
     Abs,
     Acos,
@@ -68,6 +71,7 @@
     idToDisplay,
     idToTex,
     type AssView,
+    type NNBlockView,
     type ParView,
     type RxnView,
     type VarView,
@@ -79,6 +83,7 @@
     parameters,
     assignments,
     reactions,
+    nnBlocks,
     onSave,
     popovertarget,
   }: {
@@ -87,15 +92,26 @@
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
     popovertarget: string;
     onSave: (fn: Base) => void;
   } = $props();
 
+  // NN block weights/biases must never be a pickable symbol here (ADR 0005
+  // §2.1.3) — a hand-written equation referencing one would silently break
+  // whenever the block is resized/refitted, since a block is authored as
+  // one opaque unit, not individual named parameters.
   let argNames: string[][] = $derived.by(() => {
+    const selectableParams = parameters.filter(
+      (el) => !nnBlocks.some((b) => isNNBlockOwnedParamName(el.id, b.id)),
+    );
     return [
       ["time", "time"],
       ...variables.map((el) => [el.id, defaultValue(el.displayName, el.id)]),
-      ...parameters.map((el) => [el.id, defaultValue(el.displayName, el.id)]),
+      ...selectableParams.map((el) => [
+        el.id,
+        defaultValue(el.displayName, el.id),
+      ]),
       ...assignments.map((el) => [el.id, defaultValue(el.displayName, el.id)]),
     ];
   });

--- a/src/lib/Fit.svelte
+++ b/src/lib/Fit.svelte
@@ -277,10 +277,11 @@
 
     const parNames = model.getParameterNames();
 
-    // Every weight/bias of every *trained* NN block joins the fitted set —
-    // always in linear space, never log-space (ADR 0005 §2.1.2: weights must
-    // range over all reals). Untrained blocks keep their current weights
-    // fixed and are simply left out of fitIdx.
+    // Every weight/bias, and the block's own trainable scale factor, of
+    // every *trained* NN block joins the fitted set — always in linear
+    // space, never log-space (ADR 0005 §2.1.2: weights must range over all
+    // reals, and scale can go negative too). Untrained blocks keep their
+    // current weights/scale fixed and are simply left out of fitIdx.
     const nnBlockParamNames: string[] = [];
     for (const [key, config] of model.nnBlocks) {
       if (!config.trained) continue;

--- a/src/lib/Fit.svelte
+++ b/src/lib/Fit.svelte
@@ -10,7 +10,11 @@
 
 <script lang="ts">
   import { LineChart } from "@computational-biology-aachen/design";
-  import type { ModelBuilderBase } from "@computational-biology-aachen/mxlweb-core";
+  import type {
+    FitBackend,
+    ModelBuilderBase,
+  } from "@computational-biology-aachen/mxlweb-core";
+  import { SvelteSet } from "svelte/reactivity";
   import type { ParsedCsv } from "./csvParse";
   import type { FitParameterConfig, FitTargetMapping } from "./index";
   import SimErrDisplay from "./SimErrDisplay.svelte";
@@ -66,13 +70,36 @@
 
   // ---- Parameter selection -------------------------------------------
 
+  // NN block weights/biases live in model.parameters like any other
+  // parameter, but are never individual table rows (ADR 0005 §2.1.3) — a
+  // 6×64 block is ≈20,800 of them. Fitting them is the block's own
+  // "trained" toggle (TableNNBlocks), not a per-row checkbox here.
+  let nnBlockOwnedParams = $derived.by(() => {
+    const owned = new SvelteSet<string>();
+    for (const key of model.nnBlocks.keys()) {
+      const wPrefix = `${key}_w`;
+      const bPrefix = `${key}_b`;
+      for (const name of model.parameters.keys()) {
+        if (name.startsWith(wPrefix) || name.startsWith(bPrefix)) {
+          owned.add(name);
+        }
+      }
+    }
+    return owned;
+  });
+  let hasTrainedNNBlock = $derived(
+    [...model.nnBlocks.values()].some((b) => b.trained),
+  );
+
   // Not all parameters fit by default (ADR 0004 §2.4) — a parameter not yet
   // in fitParameters defaults to unchecked.
   let paramRows = $derived(
-    [...model.parameters.keys()].map((id) => {
-      const existing = fitParameters.find((p) => p.id === id);
-      return existing ?? { id, fit: false, logSpace: true };
-    }),
+    [...model.parameters.keys()]
+      .filter((id) => !nnBlockOwnedParams.has(id))
+      .map((id) => {
+        const existing = fitParameters.find((p) => p.id === id);
+        return existing ?? { id, fit: false, logSpace: true };
+      }),
   );
 
   function updateParamRow(id: string, update: Partial<FitParameterConfig>) {
@@ -183,8 +210,9 @@
       return;
     }
     const { fitIdx, ok } = fitTargets();
-    if (!ok) {
-      errorMsg = "Select at least one parameter to fit.";
+    if (!ok && !hasTrainedNNBlock) {
+      errorMsg =
+        "Select at least one parameter to fit, or enable training on an NN block.";
       return;
     }
 
@@ -224,6 +252,16 @@
     const derivedTargets = targets.filter((t) => t.kind === "derived");
     const derivedKeys = derivedTargets.map((t) => t.key);
 
+    // v1's "adjoint" backend only supports state-variable targets (see
+    // FitInitRequest.adjointWat's doc comment) — reject up front rather than
+    // let fit_init fail deep in the WASM boundary.
+    if (hasTrainedNNBlock && derivedTargets.length > 0) {
+      errorMsg =
+        "Training an NN block requires every fit target to be a state variable, not a derived quantity.";
+      running = false;
+      return;
+    }
+
     let derivedWat: string | undefined;
     try {
       derivedWat =
@@ -250,18 +288,63 @@
     });
 
     const parNames = model.getParameterNames();
-    const logFlags = fitIdx.map(
-      (i) => fitParameters.find((p) => p.id === parNames[i])?.logSpace ?? true,
-    );
+
+    // Every weight/bias of every *trained* NN block joins the fitted set —
+    // always in linear space, never log-space (ADR 0005 §2.1.2: weights must
+    // range over all reals). Untrained blocks keep their current weights
+    // fixed and are simply left out of fitIdx.
+    const nnBlockParamNames: string[] = [];
+    for (const [key, config] of model.nnBlocks) {
+      if (!config.trained) continue;
+      const wPrefix = `${key}_w`;
+      const bPrefix = `${key}_b`;
+      for (const name of parNames) {
+        if (name.startsWith(wPrefix) || name.startsWith(bPrefix)) {
+          nnBlockParamNames.push(name);
+        }
+      }
+    }
+    const nnBlockFitIdx = nnBlockParamNames.map((name) => parNames.indexOf(name));
+    const combinedFitIdx = [...fitIdx, ...nnBlockFitIdx];
+
+    const logFlags = [
+      ...fitIdx.map(
+        (i) =>
+          fitParameters.find((p) => p.id === parNames[i])?.logSpace ?? true,
+      ),
+      ...nnBlockFitIdx.map(() => false),
+    ];
     // A per-row "initial guess" override (edited in the param table) starts
     // the fit from a value other than the model's current live parameter —
-    // falls back to that live value where no override was set.
+    // falls back to that live value where no override was set. NN weights
+    // have no such override — they start from their current (Glorot-
+    // initialized or previously-fitted) value, like any un-overridden row.
     const pars = model
       .resolveParameters()
       .map(
         (v, i) =>
           fitParameters.find((p) => p.id === parNames[i])?.initialGuess ?? v,
       );
+
+    // Any trained NN block forces the adjoint backend unconditionally — a
+    // 6×64 block's ≈20,800 finite-difference forward solves under "lm" are
+    // intractable regardless of measured per-solve cost (ADR 0005 §2.4).
+    // A purely mechanistic fit leaves `backend` undefined, defaulting to "lm".
+    const backend: FitBackend | undefined =
+      nnBlockFitIdx.length > 0 ? "adjoint" : undefined;
+    let adjointWat: string | undefined;
+    if (backend === "adjoint") {
+      try {
+        adjointWat = model.buildAdjointWat(
+          combinedFitIdx.map((i) => parNames[i]),
+        );
+      } catch (e) {
+        errorMsg =
+          e instanceof Error ? e.message : "Failed to build the adjoint model.";
+        running = false;
+        return;
+      }
+    }
 
     session = new FitSession();
     session.onInitResult((result) => {
@@ -319,7 +402,7 @@
       nDerived: derivedKeys.length,
       y0: model.resolveInitialValues(),
       pars,
-      fitIdx,
+      fitIdx: combinedFitIdx,
       logFlags,
       targets: fitTargetsList.map(({ kind, index, scale }) => ({
         kind,
@@ -333,6 +416,8 @@
       rtol: 1e-8,
       atol: 1e-10,
       targetResidualNorm,
+      backend,
+      adjointWat,
     });
   }
 
@@ -355,6 +440,19 @@
       const current = model.parameters.get(row.id);
       if (!current) continue;
       model.parameters = model.parameters.set(row.id, { ...current, value });
+    }
+    // Trained NN blocks' weights/biases have no paramRows entry (§2.1.3) —
+    // written back separately, for every trained block, unconditionally.
+    for (const [key, config] of model.nnBlocks) {
+      if (!config.trained) continue;
+      const wPrefix = `${key}_w`;
+      const bPrefix = `${key}_b`;
+      for (const [name, value] of Object.entries(fittedValues)) {
+        if (!name.startsWith(wPrefix) && !name.startsWith(bPrefix)) continue;
+        const current = model.parameters.get(name);
+        if (!current) continue;
+        model.parameters = model.parameters.set(name, { ...current, value });
+      }
     }
     onApply?.();
   }
@@ -466,6 +564,12 @@
       </tbody>
     </table>
 
+    {#if hasTrainedNNBlock}
+      <p class="nn-note">
+        Also training {[...model.nnBlocks.values()].filter((b) => b.trained)
+          .length} NN block(s) — this fit uses the adjoint backend.
+      </p>
+    {/if}
     <div class="run-row">
       {#if !running}
         <button
@@ -640,6 +744,11 @@
   .target-missed {
     margin: 0;
     color: var(--color-accent, #f6a800);
+    font-size: 0.875rem;
+  }
+  .nn-note {
+    margin: 0;
+    color: var(--color-text-muted);
     font-size: 0.875rem;
   }
 </style>

--- a/src/lib/Fit.svelte
+++ b/src/lib/Fit.svelte
@@ -10,9 +10,10 @@
 
 <script lang="ts">
   import { LineChart } from "@computational-biology-aachen/design";
-  import type {
-    FitBackend,
-    ModelBuilderBase,
+  import {
+    isNNBlockOwnedParamName,
+    type FitBackend,
+    type ModelBuilderBase,
   } from "@computational-biology-aachen/mxlweb-core";
   import type { ParsedCsv } from "./csvParse";
   import type { FitParameterConfig, FitTargetMapping } from "./index";
@@ -283,10 +284,8 @@
     const nnBlockParamNames: string[] = [];
     for (const [key, config] of model.nnBlocks) {
       if (!config.trained) continue;
-      const wPrefix = `${key}_w`;
-      const bPrefix = `${key}_b`;
       for (const name of parNames) {
-        if (name.startsWith(wPrefix) || name.startsWith(bPrefix)) {
+        if (isNNBlockOwnedParamName(name, key)) {
           nnBlockParamNames.push(name);
         }
       }
@@ -432,10 +431,8 @@
     // written back separately, for every trained block, unconditionally.
     for (const [key, config] of model.nnBlocks) {
       if (!config.trained) continue;
-      const wPrefix = `${key}_w`;
-      const bPrefix = `${key}_b`;
       for (const [name, value] of Object.entries(fittedValues)) {
-        if (!name.startsWith(wPrefix) && !name.startsWith(bPrefix)) continue;
+        if (!isNNBlockOwnedParamName(name, key)) continue;
         const current = model.parameters.get(name);
         if (!current) continue;
         model.parameters = model.parameters.set(name, { ...current, value });

--- a/src/lib/Fit.svelte
+++ b/src/lib/Fit.svelte
@@ -14,7 +14,6 @@
     FitBackend,
     ModelBuilderBase,
   } from "@computational-biology-aachen/mxlweb-core";
-  import { SvelteSet } from "svelte/reactivity";
   import type { ParsedCsv } from "./csvParse";
   import type { FitParameterConfig, FitTargetMapping } from "./index";
   import SimErrDisplay from "./SimErrDisplay.svelte";
@@ -74,19 +73,7 @@
   // parameter, but are never individual table rows (ADR 0005 §2.1.3) — a
   // 6×64 block is ≈20,800 of them. Fitting them is the block's own
   // "trained" toggle (TableNNBlocks), not a per-row checkbox here.
-  let nnBlockOwnedParams = $derived.by(() => {
-    const owned = new SvelteSet<string>();
-    for (const key of model.nnBlocks.keys()) {
-      const wPrefix = `${key}_w`;
-      const bPrefix = `${key}_b`;
-      for (const name of model.parameters.keys()) {
-        if (name.startsWith(wPrefix) || name.startsWith(bPrefix)) {
-          owned.add(name);
-        }
-      }
-    }
-    return owned;
-  });
+  let nnBlockOwnedParams = $derived(model.nnBlockOwnedParameterNames());
   let hasTrainedNNBlock = $derived(
     [...model.nnBlocks.values()].some((b) => b.trained),
   );

--- a/src/lib/ModelEditor.svelte
+++ b/src/lib/ModelEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import TableAssignments from "$lib/TableAssignment.svelte";
+  import TableNNBlocks from "$lib/TableNNBlocks.svelte";
   import TableParameters from "$lib/TableParameters.svelte";
   import TableReactions from "$lib/TableReactions.svelte";
   import TableVariables from "$lib/TableVariables.svelte";
@@ -80,9 +81,17 @@
       })
       .toArray(),
   );
+  let nnBlocks = $derived(
+    parent.nnBlocks
+      .entries()
+      .map(([name, block]) => {
+        return { ...block, id: name };
+      })
+      .toArray(),
+  );
 
   let modelView = $derived(
-    new ModelView(parameters, variables, assignments, reactions),
+    new ModelView(parameters, variables, assignments, reactions, nnBlocks),
   );
   let builder = $derived(modelView.toBuilder());
   let latex = $derived(builder.buildTex());
@@ -106,6 +115,11 @@
       name: "Reactions",
       comp: TableReactions,
       icon: "rebase_edit",
+    },
+    {
+      name: "NN Blocks",
+      comp: TableNNBlocks,
+      icon: "model_training",
     },
   ];
 
@@ -174,6 +188,7 @@
       bind:parameters={parameters}
       bind:assignments={assignments}
       bind:reactions={reactions}
+      bind:nnBlocks={nnBlocks}
     />
   </div>
 
@@ -226,7 +241,7 @@
 
     @media (min-width: 768px) {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
       padding: 0;
     }
   }

--- a/src/lib/ModelEditor.svelte
+++ b/src/lib/ModelEditor.svelte
@@ -30,15 +30,17 @@
     popovertarget: string;
   } = $props();
 
-  // NN block weights/biases and generated reactions live in the same
-  // `parent.parameters`/`parent.reactions` maps as ordinary entries (no
-  // other marker distinguishes them) — but this array feeds `ModelView.
-  // toBuilder()` on Save, which must round-trip every entry's *current*
-  // value (including a fitted weight) untouched. Excluding block-owned
-  // entries here would silently drop those values from the rebuilt model
-  // instead of just hiding their rows, so the exclusion happens downstream,
-  // inside TableParameters/TableReactions themselves (ADR 0005 §2.1.3 is a
-  // display/editability rule, not a data-flow one).
+  // NN block weights/biases/scale live in the same `parent.parameters` map
+  // as ordinary entries (no other marker distinguishes them) — but this
+  // array feeds `ModelView.toBuilder()` on Save, which must round-trip
+  // every entry's *current* value (including a fitted weight) untouched.
+  // Excluding block-owned entries here would silently drop those values
+  // from the rebuilt model instead of just hiding their rows, so the
+  // exclusion happens downstream, inside TableParameters itself (ADR 0005
+  // §2.1.3 is a display/editability rule, not a data-flow one). Reactions
+  // are unaffected by this — an NN block no longer generates one at all,
+  // for any mechanism (NNBlockConfig.mechanism's doc comment), so
+  // `parent.reactions` is always purely hand-authored.
   let parameters = $derived(
     parent.parameters
       .entries()

--- a/src/lib/ModelEditor.svelte
+++ b/src/lib/ModelEditor.svelte
@@ -32,16 +32,16 @@
 
   // NN block weights/biases and generated reactions live in the same
   // `parent.parameters`/`parent.reactions` maps as ordinary entries (no
-  // other marker distinguishes them), but must never surface as individual
-  // table rows here (ADR 0005 §2.1.3) — a block is authored/resized as one
-  // unit in its own "NN Blocks" tab only.
-  let ownedParams = $derived(parent.nnBlockOwnedParameterNames());
-  let ownedReactions = $derived(parent.nnBlockOwnedReactionNames());
-
+  // other marker distinguishes them) — but this array feeds `ModelView.
+  // toBuilder()` on Save, which must round-trip every entry's *current*
+  // value (including a fitted weight) untouched. Excluding block-owned
+  // entries here would silently drop those values from the rebuilt model
+  // instead of just hiding their rows, so the exclusion happens downstream,
+  // inside TableParameters/TableReactions themselves (ADR 0005 §2.1.3 is a
+  // display/editability rule, not a data-flow one).
   let parameters = $derived(
     parent.parameters
       .entries()
-      .filter(([name]) => !ownedParams.has(name))
       .map(([name, par]) => {
         return {
           ...par,
@@ -81,7 +81,6 @@
   let reactions = $derived(
     parent.reactions
       .entries()
-      .filter(([name]) => !ownedReactions.has(name))
       .map(([name, rxn]) => {
         return {
           ...rxn,

--- a/src/lib/ModelEditor.svelte
+++ b/src/lib/ModelEditor.svelte
@@ -30,9 +30,18 @@
     popovertarget: string;
   } = $props();
 
+  // NN block weights/biases and generated reactions live in the same
+  // `parent.parameters`/`parent.reactions` maps as ordinary entries (no
+  // other marker distinguishes them), but must never surface as individual
+  // table rows here (ADR 0005 §2.1.3) — a block is authored/resized as one
+  // unit in its own "NN Blocks" tab only.
+  let ownedParams = $derived(parent.nnBlockOwnedParameterNames());
+  let ownedReactions = $derived(parent.nnBlockOwnedReactionNames());
+
   let parameters = $derived(
     parent.parameters
       .entries()
+      .filter(([name]) => !ownedParams.has(name))
       .map(([name, par]) => {
         return {
           ...par,
@@ -72,6 +81,7 @@
   let reactions = $derived(
     parent.reactions
       .entries()
+      .filter(([name]) => !ownedReactions.has(name))
       .map(([name, rxn]) => {
         return {
           ...rxn,

--- a/src/lib/OdeModelEditor.svelte
+++ b/src/lib/OdeModelEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import TableAssignments from "$lib/TableAssignment.svelte";
   import TableDifferentials from "$lib/TableDifferentials.svelte";
+  import TableNNBlocks from "$lib/TableNNBlocks.svelte";
   import TableParameters from "$lib/TableParameters.svelte";
   import {
     Button,
@@ -72,8 +73,17 @@
       .toArray(),
   );
 
+  let nnBlocks = $derived(
+    parent.nnBlocks
+      .entries()
+      .map(([name, block]) => {
+        return { ...block, id: name };
+      })
+      .toArray(),
+  );
+
   let modelView = $derived(
-    new OdeModelView(parameters, variables, assignments),
+    new OdeModelView(parameters, variables, assignments, nnBlocks),
   );
   let latex = $derived(modelView.toBuilder().buildTex());
 
@@ -89,6 +99,10 @@
     {
       name: "Assignments",
       icon: "expand",
+    },
+    {
+      name: "NN Blocks",
+      icon: "model_training",
     },
   ];
 
@@ -157,6 +171,7 @@
       parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
     />
   {:else if cur.name === "Parameters"}
     <TableParameters
@@ -164,13 +179,23 @@
       bind:parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
     />
-  {:else}
+  {:else if cur.name === "Assignments"}
     <TableAssignments
       variables={variables}
       parameters={parameters}
       bind:assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
+    />
+  {:else}
+    <TableNNBlocks
+      variables={variables}
+      parameters={parameters}
+      assignments={assignments}
+      reactions={reactions}
+      bind:nnBlocks={nnBlocks}
     />
   {/if}
 </div>
@@ -222,7 +247,7 @@
 
     @media (min-width: 768px) {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
       padding: 0;
     }
   }

--- a/src/lib/OdeModelEditor.svelte
+++ b/src/lib/OdeModelEditor.svelte
@@ -32,9 +32,14 @@
   // ODE models have no reactions; the reused tables still expect the prop.
   let reactions: RxnView = $state([]);
 
+  // NN block weights/biases must never surface as individual parameter-table
+  // rows (ADR 0005 §2.1.3) — see ModelEditor.svelte's identical filter.
+  let ownedParams = $derived(parent.nnBlockOwnedParameterNames());
+
   let parameters = $derived(
     parent.parameters
       .entries()
+      .filter(([name]) => !ownedParams.has(name))
       .map(([name, par]) => {
         return {
           ...par,

--- a/src/lib/OdeModelEditor.svelte
+++ b/src/lib/OdeModelEditor.svelte
@@ -32,14 +32,14 @@
   // ODE models have no reactions; the reused tables still expect the prop.
   let reactions: RxnView = $state([]);
 
-  // NN block weights/biases must never surface as individual parameter-table
-  // rows (ADR 0005 §2.1.3) — see ModelEditor.svelte's identical filter.
-  let ownedParams = $derived(parent.nnBlockOwnedParameterNames());
-
+  // This array feeds OdeModelView.toBuilder() on Save, which must
+  // round-trip every entry's *current* value (including a fitted NN-block
+  // weight) untouched — see ModelEditor.svelte's identical comment for why
+  // the block-owned-row exclusion happens downstream in TableParameters
+  // instead of here.
   let parameters = $derived(
     parent.parameters
       .entries()
-      .filter(([name]) => !ownedParams.has(name))
       .map(([name, par]) => {
         return {
           ...par,

--- a/src/lib/ParameterScanEditor.svelte
+++ b/src/lib/ParameterScanEditor.svelte
@@ -96,7 +96,13 @@
     }
   }
 
-  let parameterKeys = $derived([...model.parameters.keys()]);
+  // NN block weights/biases are never a valid scan target (ADR 0005 §2.1.3)
+  // — a block is trained as one unit, not swept parameter-by-parameter.
+  let parameterKeys = $derived(
+    [...model.parameters.keys()].filter(
+      (key) => !model.nnBlockOwnedParameterNames().has(key),
+    ),
+  );
 </script>
 
 <Row

--- a/src/lib/ParameterScanEditor.svelte
+++ b/src/lib/ParameterScanEditor.svelte
@@ -98,10 +98,9 @@
 
   // NN block weights/biases are never a valid scan target (ADR 0005 §2.1.3)
   // — a block is trained as one unit, not swept parameter-by-parameter.
+  let ownedParams = $derived(model.nnBlockOwnedParameterNames());
   let parameterKeys = $derived(
-    [...model.parameters.keys()].filter(
-      (key) => !model.nnBlockOwnedParameterNames().has(key),
-    ),
+    [...model.parameters.keys()].filter((key) => !ownedParams.has(key)),
   );
 </script>
 

--- a/src/lib/SteadyStateModelEditor.svelte
+++ b/src/lib/SteadyStateModelEditor.svelte
@@ -15,6 +15,7 @@
   import EditorTutorial from "./EditorTutorial.svelte";
   import {
     SteadyStateModelView,
+    type NNBlockView,
     type RxnView,
     type VarView,
   } from "./modelView";
@@ -30,10 +31,13 @@
     popovertarget: string;
   } = $props();
 
-  // Steady-state models have neither state variables nor reactions; the reused
-  // tables still expect the props.
+  // Steady-state models have neither state variables nor reactions, and
+  // can't have NN blocks either (no dx/dt for a correction term to feed
+  // into — ModelBuilderBase.wireNNBlockOutputs throws for this builder);
+  // the reused tables still expect the props.
   let variables: VarView = $state([]);
   let reactions: RxnView = $state([]);
+  let nnBlocks: NNBlockView = $state([]);
 
   let parameters = $derived(
     parent.parameters
@@ -142,6 +146,7 @@
       bind:parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
     />
   {:else}
     <TableAssignments
@@ -149,6 +154,7 @@
       parameters={parameters}
       bind:assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
     />
   {/if}
 </div>

--- a/src/lib/TableAssignment.svelte
+++ b/src/lib/TableAssignment.svelte
@@ -15,6 +15,7 @@
   import {
     idToTex,
     type AssView,
+    type NNBlockView,
     type ParView,
     type RxnView,
     type VarView,
@@ -29,11 +30,14 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    nnBlocks = $bindable(),
   }: {
     variables: VarView;
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
   } = $props();
 
   function onSaveEq(idx: number, fn: Base) {

--- a/src/lib/TableAssignment.svelte
+++ b/src/lib/TableAssignment.svelte
@@ -30,7 +30,6 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     nnBlocks = $bindable(),
   }: {
     variables: VarView;
@@ -204,6 +203,7 @@
       parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
       onSave={(root) => onSaveEq(idx, root)}
       popovertarget={`eq-editor-${idx}`}
     />

--- a/src/lib/TableDifferentials.svelte
+++ b/src/lib/TableDifferentials.svelte
@@ -16,6 +16,7 @@
   import {
     idToTex,
     type AssView,
+    type NNBlockView,
     type OdeVariable,
     type OdeVarView,
     type ParView,
@@ -32,11 +33,14 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    nnBlocks = $bindable(),
   }: {
     variables: OdeVarView;
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
   } = $props();
 
   function onSaveSlider(idx: number, update: OdeVariable) {

--- a/src/lib/TableDifferentials.svelte
+++ b/src/lib/TableDifferentials.svelte
@@ -33,7 +33,6 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     nnBlocks = $bindable(),
   }: {
     variables: OdeVarView;
@@ -273,6 +272,7 @@
       parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
       onSave={(fn) => onSaveDifferential(idx, fn)}
       popovertarget={`diff-editor-${idx}`}
     />
@@ -291,6 +291,7 @@
         parameters={parameters}
         assignments={assignments}
         reactions={reactions}
+        nnBlocks={nnBlocks}
         onSave={(fn) => onSaveInitialAssignment(idx, fn)}
         popovertarget={`diff-ia-editor-${idx}`}
       />

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -82,6 +82,10 @@
         // freshly-initialized network doesn't blow up the first fit
         // iteration; the scale itself is trainable too, same as any weight.
         scale: 0.1,
+        // additive: dx/dt = f + scale*NN. multiplicative: dx/dt =
+        // f*(1 + scale*NN) — defaults to additive, the only mechanism that
+        // existed before this selector.
+        mechanism: "additive",
       },
     ];
   }
@@ -159,6 +163,22 @@
   />
 {/snippet}
 
+{#snippet mechanismField(idx: number)}
+  <select
+    aria-label="Mechanism"
+    bind:value={
+      () => nnBlocks[idx].mechanism,
+      (value) => {
+        nnBlocks[idx].mechanism = value;
+        nnBlocks = nnBlocks.slice();
+      }
+    }
+  >
+    <option value="additive">Additive: f + s·NN(x)</option>
+    <option value="multiplicative">Multiplicative: f · (1 + s·NN(x))</option>
+  </select>
+{/snippet}
+
 {#snippet trainedField(idx: number)}
   <input
     type="checkbox"
@@ -203,6 +223,10 @@
           <div class="card-input">{@render scaleField(idx)}</div>
         </div>
         <div class="card-row">
+          <span class="card-label">Mechanism</span>
+          <div class="card-input">{@render mechanismField(idx)}</div>
+        </div>
+        <div class="card-row">
           <span class="card-label">Train when fitting</span>
           {@render trainedField(idx)}
         </div>
@@ -220,6 +244,7 @@
         <th>Name</th>
         <th>Layers</th>
         <th>Output scale</th>
+        <th>Mechanism</th>
         <th>Train</th>
         <th>Actions</th>
       </tr>
@@ -230,6 +255,7 @@
           <td>{block.id}</td>
           <td>{@render depthWidthField(idx)}</td>
           <td>{@render scaleField(idx)}</td>
+          <td>{@render mechanismField(idx)}</td>
           <td>{@render trainedField(idx)}</td>
           <td class="actions">{@render actions(idx, block.id)}</td>
         </tr>
@@ -261,7 +287,8 @@
     width: 4rem;
   }
 
-  input {
+  input,
+  select {
     border: var(--border-transparent);
     border-radius: var(--radius-lg);
     background-color: transparent;
@@ -269,7 +296,8 @@
     width: 100%;
     font-size: 0.875rem;
   }
-  input:hover {
+  input:hover,
+  select:hover {
     border: var(--border-primary);
   }
 

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -78,14 +78,15 @@
         seed: Date.now() + nextSeed,
         targets: [...allVariableNames],
         trained: true,
-        // dx/dt = f(x,p,t) + scale * NN(x,θ) — starts small so a bigger
-        // freshly-initialized network doesn't blow up the first fit
+        // dx/dt = f(x,p,t) * (1 + scale * NN(x,θ)) — starts small so a
+        // bigger freshly-initialized network doesn't blow up the first fit
         // iteration; the scale itself is trainable too, same as any weight.
-        scale: 0.1,
+        scale: 0.01,
         // additive: dx/dt = f + scale*NN. relative_multiply: dx/dt =
-        // f*(1 + scale*NN). multiply: dx/dt = f*scale*NN — defaults to
-        // additive, the only mechanism that existed before this selector.
-        mechanism: "additive",
+        // f*(1 + scale*NN) — default, since an untrained network then
+        // leaves f unchanged regardless of scale. multiply: dx/dt =
+        // f*scale*NN.
+        mechanism: "relative_multiply",
       },
     ];
   }

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -82,9 +82,9 @@
         // freshly-initialized network doesn't blow up the first fit
         // iteration; the scale itself is trainable too, same as any weight.
         scale: 0.1,
-        // additive: dx/dt = f + scale*NN. multiplicative: dx/dt =
-        // f*(1 + scale*NN) — defaults to additive, the only mechanism that
-        // existed before this selector.
+        // additive: dx/dt = f + scale*NN. relative_multiply: dx/dt =
+        // f*(1 + scale*NN). multiply: dx/dt = f*scale*NN — defaults to
+        // additive, the only mechanism that existed before this selector.
         mechanism: "additive",
       },
     ];
@@ -175,7 +175,8 @@
     }
   >
     <option value="additive">Additive: f + s·NN(x)</option>
-    <option value="multiplicative">Multiplicative: f · (1 + s·NN(x))</option>
+    <option value="relative_multiply">Relative multiply: f · (1 + s·NN(x))</option>
+    <option value="multiply">Multiply: f · s·NN(x)</option>
   </select>
 {/snippet}
 

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -20,7 +20,6 @@
   // parameters/assignments involved) and only edits `nnBlocks`.
   let {
     variables = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     parameters = $bindable(),
     // eslint-disable-next-line no-useless-assignment
     assignments = $bindable(),
@@ -79,8 +78,43 @@
         seed: Date.now() + nextSeed,
         targets: [...allVariableNames],
         trained: true,
+        // dx/dt = f(x,p,t) + scale * NN(x,θ) — starts small so a bigger
+        // freshly-initialized network doesn't blow up the first fit
+        // iteration; the scale itself is trainable too, same as any weight.
+        scale: 0.1,
       },
     ];
+  }
+
+  // The block's scale is `${blockId}_scale` in `this.parameters` — an
+  // ordinary, trainable Parameter, per nnBlock.ts — but only once the block
+  // has actually been through a Save (`ModelView.toBuilder()` is what first
+  // calls `addNNBlock`, materializing it there). Before that first Save,
+  // `parameters` (unfiltered but sourced from `parent.parameters`, per
+  // ModelEditor.svelte's comment on why it stays that way) doesn't have an
+  // entry for a block added in *this* session yet, so editing falls back to
+  // `nnBlocks[idx].scale` — exactly the value that first Save will use to
+  // seed the real parameter.
+  function scaleParamName(blockId: string): string {
+    return `${blockId}_scale`;
+  }
+  function currentScale(idx: number): number {
+    const existing = parameters.find(
+      (p) => p.id === scaleParamName(nnBlocks[idx].id),
+    );
+    return existing?.value ?? nnBlocks[idx].scale;
+  }
+  function setScale(idx: number, value: number) {
+    const paramIdx = parameters.findIndex(
+      (p) => p.id === scaleParamName(nnBlocks[idx].id),
+    );
+    if (paramIdx >= 0) {
+      parameters[paramIdx] = { ...parameters[paramIdx], value };
+      parameters = parameters.slice();
+    } else {
+      nnBlocks[idx].scale = value;
+      nnBlocks = nnBlocks.slice();
+    }
   }
 </script>
 
@@ -114,6 +148,15 @@
       }
     />
   </div>
+{/snippet}
+
+{#snippet scaleField(idx: number)}
+  <input
+    type="number"
+    step="any"
+    aria-label="Output scale"
+    bind:value={() => currentScale(idx), (value) => setScale(idx, value)}
+  />
 {/snippet}
 
 {#snippet trainedField(idx: number)}
@@ -156,6 +199,10 @@
           <div class="card-input">{@render depthWidthField(idx)}</div>
         </div>
         <div class="card-row">
+          <span class="card-label">Output scale</span>
+          <div class="card-input">{@render scaleField(idx)}</div>
+        </div>
+        <div class="card-row">
           <span class="card-label">Train when fitting</span>
           {@render trainedField(idx)}
         </div>
@@ -172,6 +219,7 @@
       <tr>
         <th>Name</th>
         <th>Layers</th>
+        <th>Output scale</th>
         <th>Train</th>
         <th>Actions</th>
       </tr>
@@ -181,6 +229,7 @@
         <tr>
           <td>{block.id}</td>
           <td>{@render depthWidthField(idx)}</td>
+          <td>{@render scaleField(idx)}</td>
           <td>{@render trainedField(idx)}</td>
           <td class="actions">{@render actions(idx, block.id)}</td>
         </tr>

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -1,0 +1,372 @@
+<script lang="ts">
+  import { Button, ButtonIcon as IconButton } from "@computational-biology-aachen/design";
+  import { MediaQuery } from "svelte/reactivity";
+  import {
+    type AssView,
+    type NNBlockView,
+    type ParView,
+    type RxnView,
+    type VarView,
+  } from "./modelView";
+  import TableSearch from "./TableSearch.svelte";
+  import { fuzzyMatch } from "./utils";
+
+  const md = new MediaQuery("max-width: 768px");
+
+  // The four other model views are received for the same uniform table API
+  // every other table component gets (see ModelEditor.svelte) — this one
+  // reads `variables`/`parameters`/`assignments` (valid NN-block inputs) and
+  // `variables` again (valid targets — a block corrects a variable's
+  // dynamics, so it can't target a parameter or assignment), but only edits
+  // `nnBlocks`.
+  let {
+    variables = $bindable(),
+    parameters = $bindable(),
+    assignments = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    reactions = $bindable(),
+    nnBlocks = $bindable(),
+  }: {
+    variables: VarView;
+    parameters: ParView;
+    assignments: AssView;
+    reactions: RxnView;
+    nnBlocks: NNBlockView;
+  } = $props();
+
+  // Every name a block could legitimately reference as an input.
+  let availableInputs = $derived([
+    ...variables.map((v) => v.id),
+    ...parameters.map((p) => p.id),
+    ...assignments.map((a) => a.id),
+  ]);
+  let availableTargets = $derived(variables.map((v) => v.id));
+
+  /** Parses a comma-separated name list, dropping blanks — used for the
+   * inputs/targets fields below, which are plain text rather than a
+   * validated multi-select (no such picker component exists yet in this
+   * app; typed names are checked against `availableInputs`/
+   * `availableTargets` and flagged, not silently accepted either way). */
+  function parseNames(text: string): string[] {
+    return text
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
+  function unknownNames(names: string[], available: string[]): string[] {
+    const known = new Set(available);
+    return names.filter((n) => !known.has(n));
+  }
+
+  let query = $state("");
+  let filtered = $derived(
+    nnBlocks
+      .map((block, idx) => ({ block, idx }))
+      .filter(({ block }) => fuzzyMatch(block.id, query)),
+  );
+
+  let nextSeed = 0;
+  function addBlock() {
+    nextSeed += 1;
+    nnBlocks = [
+      ...nnBlocks,
+      {
+        id: `block${nnBlocks.length}`,
+        inputs: [],
+        depth: 1,
+        width: 4,
+        seed: Date.now() + nextSeed,
+        targets: [],
+        trained: true,
+      },
+    ];
+  }
+</script>
+
+{#snippet inputsField(idx: number)}
+  <input
+    type="text"
+    placeholder="e.g. x, y"
+    bind:value={
+      () => nnBlocks[idx].inputs.join(", "),
+      (value) => {
+        nnBlocks[idx].inputs = parseNames(value);
+        nnBlocks = nnBlocks.slice();
+      }
+    }
+  />
+  {#if unknownNames(nnBlocks[idx].inputs, availableInputs).length > 0}
+    <p class="warning">
+      Not in this model: {unknownNames(nnBlocks[idx].inputs, availableInputs).join(", ")}
+    </p>
+  {/if}
+{/snippet}
+
+{#snippet targetsField(idx: number)}
+  <input
+    type="text"
+    placeholder="e.g. x"
+    bind:value={
+      () => nnBlocks[idx].targets.join(", "),
+      (value) => {
+        nnBlocks[idx].targets = parseNames(value);
+        nnBlocks = nnBlocks.slice();
+      }
+    }
+  />
+  {#if unknownNames(nnBlocks[idx].targets, availableTargets).length > 0}
+    <p class="warning">
+      Not a variable in this model: {unknownNames(
+        nnBlocks[idx].targets,
+        availableTargets,
+      ).join(", ")}
+    </p>
+  {/if}
+{/snippet}
+
+{#snippet depthWidthField(idx: number)}
+  <div class="pair">
+    <input
+      type="number"
+      min="1"
+      step="1"
+      aria-label="Hidden layers"
+      bind:value={
+        () => nnBlocks[idx].depth,
+        (value) => {
+          nnBlocks[idx].depth = Math.max(1, Math.round(value));
+          nnBlocks = nnBlocks.slice();
+        }
+      }
+    />
+    <span>×</span>
+    <input
+      type="number"
+      min="1"
+      step="1"
+      aria-label="Layer width"
+      bind:value={
+        () => nnBlocks[idx].width,
+        (value) => {
+          nnBlocks[idx].width = Math.max(1, Math.round(value));
+          nnBlocks = nnBlocks.slice();
+        }
+      }
+    />
+  </div>
+{/snippet}
+
+{#snippet trainedField(idx: number)}
+  <input
+    type="checkbox"
+    bind:checked={
+      () => nnBlocks[idx].trained,
+      (value) => {
+        nnBlocks[idx].trained = value;
+        nnBlocks = nnBlocks.slice();
+      }
+    }
+  />
+{/snippet}
+
+{#snippet actions(_idx: number, id: string)}
+  <IconButton
+    icon="close"
+    onclick={() => {
+      nnBlocks = nnBlocks.filter((b) => b.id !== id);
+    }}
+  />
+{/snippet}
+
+<div class="padding">
+  <TableSearch bind:value={query} />
+</div>
+
+{#if md.current}
+  <!-- Card layout for mobile -->
+  <div class="card-container">
+    {#each filtered as { block, idx } (block.id)}
+      <div class="card">
+        <div class="card-row">
+          <span class="card-label">Name</span>
+          {block.id}
+        </div>
+        <div class="card-row">
+          <span class="card-label">Inputs</span>
+          <div class="card-input">{@render inputsField(idx)}</div>
+        </div>
+        <div class="card-row">
+          <span class="card-label">Architecture</span>
+          <div class="card-input">{@render depthWidthField(idx)}</div>
+        </div>
+        <div class="card-row">
+          <span class="card-label">Targets</span>
+          <div class="card-input">{@render targetsField(idx)}</div>
+        </div>
+        <div class="card-row">
+          <span class="card-label">Train when fitting</span>
+          {@render trainedField(idx)}
+        </div>
+        <div class="card-row card-actions">
+          {@render actions(idx, block.id)}
+        </div>
+      </div>
+    {/each}
+  </div>
+{:else}
+  <!-- Table layout for desktop -->
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Inputs</th>
+        <th>Layers</th>
+        <th>Targets</th>
+        <th>Train</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each filtered as { block, idx } (block.id)}
+        <tr>
+          <td>{block.id}</td>
+          <td>{@render inputsField(idx)}</td>
+          <td>{@render depthWidthField(idx)}</td>
+          <td>{@render targetsField(idx)}</td>
+          <td>{@render trainedField(idx)}</td>
+          <td class="actions">{@render actions(idx, block.id)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/if}
+{#if query !== "" && filtered.length === 0}
+  <p class="empty">No items match “{query}”.</p>
+{/if}
+<div class="padding">
+  <Button onclick={addBlock}>add NN block</Button>
+</div>
+
+<style>
+  .padding {
+    padding: 1rem;
+  }
+  .empty {
+    padding: 0 1rem;
+    color: var(--color-text-muted);
+  }
+  .warning {
+    margin: 0.25rem 0 0;
+    color: var(--color-warning, #b45309);
+    font-size: 0.75rem;
+  }
+  .pair {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .pair input {
+    width: 4rem;
+  }
+
+  input {
+    border: var(--border-transparent);
+    border-radius: var(--radius-lg);
+    background-color: transparent;
+    padding: 0.35rem 0.5rem;
+    width: 100%;
+    font-size: 0.875rem;
+  }
+  input:hover {
+    border: var(--border-primary);
+  }
+
+  .card-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: var(--shadow);
+    border: var(--border);
+    border-radius: 0.5rem;
+    background-color: var(--color-surface);
+    padding: 1rem;
+  }
+  .card-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .card-label {
+    color: #6b7280;
+    font-weight: var(--weight-bold);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    text-transform: uppercase;
+  }
+  .card-input {
+    width: 100%;
+  }
+  .card-actions {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    border-top: 1px solid #e5e7eb;
+    padding-top: 0.5rem;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    overflow-x: auto;
+    text-align: left;
+    text-indent: 0;
+  }
+  thead th:first-of-type {
+    border-top-left-radius: 0.5rem;
+  }
+  thead th:last-of-type {
+    border-top-right-radius: 0.5rem;
+  }
+  tbody tr:last-of-type td:first-of-type {
+    border-bottom-left-radius: 0.5rem;
+  }
+  tbody tr:last-of-type td:last-of-type {
+    border-bottom-right-radius: 0.5rem;
+  }
+  th:last-child,
+  td:last-child {
+    width: 3rem;
+    text-align: center;
+  }
+  th {
+    background-color: #e5e7eb;
+    padding: 1rem 1.5rem;
+    font-weight: var(--weight-bold);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    text-transform: uppercase;
+  }
+  td {
+    padding: 1rem 1.5rem;
+  }
+  tr {
+    background-color: var(--color-surface);
+  }
+  tr:hover {
+    transition-duration: 150ms;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    background-color: lch(from var(--color-surface) calc(l - 5) c h);
+  }
+  td.actions {
+    display: flex;
+    gap: 0 10px;
+    width: 7rem;
+  }
+</style>

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Button, ButtonIcon as IconButton } from "@computational-biology-aachen/design";
-  import { isNNBlockOwnedParamName } from "@computational-biology-aachen/mxlweb-core";
   import { MediaQuery } from "svelte/reactivity";
   import {
     type AssView,
@@ -16,13 +15,14 @@
 
   // The four other model views are received for the same uniform table API
   // every other table component gets (see ModelEditor.svelte) — this one
-  // reads `variables`/`parameters`/`assignments` (valid NN-block inputs) and
-  // `variables` again (valid targets — a block corrects a variable's
-  // dynamics, so it can't target a parameter or assignment), but only edits
-  // `nnBlocks`.
+  // only actually reads `variables` (a block's fixed input *and* target set:
+  // it reads every state variable and corrects every state variable, no
+  // parameters/assignments involved) and only edits `nnBlocks`.
   let {
     variables = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
     parameters = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
     assignments = $bindable(),
     // eslint-disable-next-line no-useless-assignment
     reactions = $bindable(),
@@ -35,35 +35,29 @@
     nnBlocks: NNBlockView;
   } = $props();
 
-  // Every name a block could legitimately reference as an input — excludes
-  // any block's own generated weights/biases (including this block's own,
-  // mid-edit): a block reads existing model quantities, never another
-  // block's raw internal parameters.
-  let availableInputs = $derived([
-    ...variables.map((v) => v.id),
-    ...parameters
-      .filter((p) => !nnBlocks.some((b) => isNNBlockOwnedParamName(p.id, b.id)))
-      .map((p) => p.id),
-    ...assignments.map((a) => a.id),
-  ]);
-  let availableTargets = $derived(variables.map((v) => v.id));
+  // A block always reads every state variable as input and corrects every
+  // state variable as output — no per-block picker (not even for the inputs/
+  // targets themselves, which used to be free-text fields; those are gone
+  // too, not just hidden). Letting a user hand-select a subset, or parameters
+  // into the input set, produced confusing, easy-to-break configurations (a
+  // block silently going stale against the model it's meant to track).
+  let allVariableNames = $derived(variables.map((v) => v.id));
 
-  /** Parses a comma-separated name list, dropping blanks — used for the
-   * inputs/targets fields below, which are plain text rather than a
-   * validated multi-select (no such picker component exists yet in this
-   * app; typed names are checked against `availableInputs`/
-   * `availableTargets` and flagged, not silently accepted either way). */
-  function parseNames(text: string): string[] {
-    return text
-      .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
+  function sameNames(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((name, i) => name === b[i]);
   }
 
-  function unknownNames(names: string[], available: string[]): string[] {
-    const known = new Set(available);
-    return names.filter((n) => !known.has(n));
-  }
+  // Keeps every block's inputs/targets equal to "every state variable" even
+  // when the model's variable set changes on some other tab without this
+  // one being touched at all.
+  $effect(() => {
+    const next = nnBlocks.map((b) =>
+      sameNames(b.inputs, allVariableNames) && sameNames(b.targets, allVariableNames)
+        ? b
+        : { ...b, inputs: [...allVariableNames], targets: [...allVariableNames] },
+    );
+    if (next.some((b, i) => b !== nnBlocks[i])) nnBlocks = next;
+  });
 
   let query = $state("");
   let filtered = $derived(
@@ -79,57 +73,16 @@
       ...nnBlocks,
       {
         id: `block${nnBlocks.length}`,
-        inputs: [],
+        inputs: [...allVariableNames],
         depth: 1,
         width: 4,
         seed: Date.now() + nextSeed,
-        targets: [],
+        targets: [...allVariableNames],
         trained: true,
       },
     ];
   }
 </script>
-
-{#snippet inputsField(idx: number)}
-  <input
-    type="text"
-    placeholder="e.g. x, y"
-    bind:value={
-      () => nnBlocks[idx].inputs.join(", "),
-      (value) => {
-        nnBlocks[idx].inputs = parseNames(value);
-        nnBlocks = nnBlocks.slice();
-      }
-    }
-  />
-  {#if unknownNames(nnBlocks[idx].inputs, availableInputs).length > 0}
-    <p class="warning">
-      Not in this model: {unknownNames(nnBlocks[idx].inputs, availableInputs).join(", ")}
-    </p>
-  {/if}
-{/snippet}
-
-{#snippet targetsField(idx: number)}
-  <input
-    type="text"
-    placeholder="e.g. x"
-    bind:value={
-      () => nnBlocks[idx].targets.join(", "),
-      (value) => {
-        nnBlocks[idx].targets = parseNames(value);
-        nnBlocks = nnBlocks.slice();
-      }
-    }
-  />
-  {#if unknownNames(nnBlocks[idx].targets, availableTargets).length > 0}
-    <p class="warning">
-      Not a variable in this model: {unknownNames(
-        nnBlocks[idx].targets,
-        availableTargets,
-      ).join(", ")}
-    </p>
-  {/if}
-{/snippet}
 
 {#snippet depthWidthField(idx: number)}
   <div class="pair">
@@ -199,16 +152,8 @@
           {block.id}
         </div>
         <div class="card-row">
-          <span class="card-label">Inputs</span>
-          <div class="card-input">{@render inputsField(idx)}</div>
-        </div>
-        <div class="card-row">
           <span class="card-label">Architecture</span>
           <div class="card-input">{@render depthWidthField(idx)}</div>
-        </div>
-        <div class="card-row">
-          <span class="card-label">Targets</span>
-          <div class="card-input">{@render targetsField(idx)}</div>
         </div>
         <div class="card-row">
           <span class="card-label">Train when fitting</span>
@@ -226,9 +171,7 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Inputs</th>
         <th>Layers</th>
-        <th>Targets</th>
         <th>Train</th>
         <th>Actions</th>
       </tr>
@@ -237,9 +180,7 @@
       {#each filtered as { block, idx } (block.id)}
         <tr>
           <td>{block.id}</td>
-          <td>{@render inputsField(idx)}</td>
           <td>{@render depthWidthField(idx)}</td>
-          <td>{@render targetsField(idx)}</td>
           <td>{@render trainedField(idx)}</td>
           <td class="actions">{@render actions(idx, block.id)}</td>
         </tr>
@@ -261,11 +202,6 @@
   .empty {
     padding: 0 1rem;
     color: var(--color-text-muted);
-  }
-  .warning {
-    margin: 0.25rem 0 0;
-    color: var(--color-warning, #b45309);
-    font-size: 0.75rem;
   }
   .pair {
     display: flex;

--- a/src/lib/TableNNBlocks.svelte
+++ b/src/lib/TableNNBlocks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Button, ButtonIcon as IconButton } from "@computational-biology-aachen/design";
+  import { isNNBlockOwnedParamName } from "@computational-biology-aachen/mxlweb-core";
   import { MediaQuery } from "svelte/reactivity";
   import {
     type AssView,
@@ -34,10 +35,15 @@
     nnBlocks: NNBlockView;
   } = $props();
 
-  // Every name a block could legitimately reference as an input.
+  // Every name a block could legitimately reference as an input — excludes
+  // any block's own generated weights/biases (including this block's own,
+  // mid-edit): a block reads existing model quantities, never another
+  // block's raw internal parameters.
   let availableInputs = $derived([
     ...variables.map((v) => v.id),
-    ...parameters.map((p) => p.id),
+    ...parameters
+      .filter((p) => !nnBlocks.some((b) => isNNBlockOwnedParamName(p.id, b.id)))
+      .map((p) => p.id),
     ...assignments.map((a) => a.id),
   ]);
   let availableTargets = $derived(variables.map((v) => v.id));

--- a/src/lib/TableParameters.svelte
+++ b/src/lib/TableParameters.svelte
@@ -11,6 +11,7 @@
   import { MediaQuery } from "svelte/reactivity";
   import {
     type AssView,
+    type NNBlockView,
     type Parameter,
     type ParView,
     type RxnView,
@@ -23,7 +24,7 @@
 
   const md = new MediaQuery("max-width: 768px");
 
-  // The four model views are received for a uniform table API (see
+  // All five model views are received for a uniform table API (see
   // OdeModelEditor), but this table only reads/edits `parameters`.
   let {
     // eslint-disable-next-line no-useless-assignment
@@ -33,11 +34,14 @@
     assignments = $bindable(),
     // eslint-disable-next-line no-useless-assignment
     reactions = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    nnBlocks = $bindable(),
   }: {
     variables: VarView;
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
   } = $props();
 
   function onSaveSlider(idx: number, update: Variable | Parameter) {

--- a/src/lib/TableParameters.svelte
+++ b/src/lib/TableParameters.svelte
@@ -7,8 +7,9 @@
   import {
     defaultTexName,
     defaultValue,
+    isNNBlockOwnedParamName,
   } from "@computational-biology-aachen/mxlweb-core";
-  import { MediaQuery } from "svelte/reactivity";
+  import { MediaQuery, SvelteSet } from "svelte/reactivity";
   import {
     type AssView,
     type NNBlockView,
@@ -34,7 +35,6 @@
     assignments = $bindable(),
     // eslint-disable-next-line no-useless-assignment
     reactions = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     nnBlocks = $bindable(),
   }: {
     variables: VarView;
@@ -49,10 +49,26 @@
     parameters = parameters.slice();
   }
 
+  // NN block weights/biases must never surface as individual rows here
+  // (ADR 0005 §2.1.3) — `parameters` itself stays the full, unfiltered
+  // array (ModelEditor.svelte round-trips it through toBuilder() on Save,
+  // which needs every entry's live value, fitted or not), so the exclusion
+  // happens only in what this table renders/edits.
+  let ownedParamIds = $derived.by(() => {
+    const owned = new SvelteSet<string>();
+    for (const par of parameters) {
+      if (nnBlocks.some((b) => isNNBlockOwnedParamName(par.id, b.id))) {
+        owned.add(par.id);
+      }
+    }
+    return owned;
+  });
+
   let query = $state("");
   let filtered = $derived(
     parameters
       .map((par, idx) => ({ par, idx }))
+      .filter(({ par }) => !ownedParamIds.has(par.id))
       .filter(({ par }) =>
         fuzzyMatch(defaultValue(par.displayName, par.id), query),
       ),

--- a/src/lib/TableReactions.svelte
+++ b/src/lib/TableReactions.svelte
@@ -255,6 +255,7 @@
       parameters={parameters}
       assignments={assignments}
       reactions={reactions}
+      nnBlocks={nnBlocks}
       onSave={(root) => onSaveEq(idx, root)}
       popovertarget={`eq-editor-${idx}`}
     />

--- a/src/lib/TableReactions.svelte
+++ b/src/lib/TableReactions.svelte
@@ -20,6 +20,7 @@
   import {
     idToTex,
     type AssView,
+    type NNBlockView,
     type ParView,
     type RxnView,
     type Stoichiometry,
@@ -36,11 +37,14 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    nnBlocks = $bindable(),
   }: {
     variables: VarView;
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
   } = $props();
 
   function onSaveEq(idx: number, fn: Base) {

--- a/src/lib/TableReactions.svelte
+++ b/src/lib/TableReactions.svelte
@@ -8,6 +8,7 @@
   import {
     defaultTexName,
     defaultValue,
+    nnBlockReactionKey,
     stoichToTex,
   } from "@computational-biology-aachen/mxlweb-core";
   import {
@@ -15,7 +16,7 @@
     Name,
     Num,
   } from "@computational-biology-aachen/mxlweb-core/mathml";
-  import { MediaQuery } from "svelte/reactivity";
+  import { MediaQuery, SvelteSet } from "svelte/reactivity";
   import EqEditor from "./EqEditor.svelte";
   import {
     idToTex,
@@ -37,7 +38,6 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     nnBlocks = $bindable(),
   }: {
     variables: VarView;
@@ -60,10 +60,24 @@
     idToTex(variables, parameters, assignments, reactions),
   );
 
+  // An NN block's generated reaction lives in this same `reactions` array
+  // (ModelEditor.svelte's copy is unfiltered, so Save round-trips it
+  // correctly), but must never be an editable/deletable row here (ADR 0005
+  // §2.1.3) — its rate law is machine-generated and changes only through
+  // fitting, never by hand.
+  let ownedReactionIds = $derived.by(() => {
+    const owned = new SvelteSet<string>();
+    for (const b of nnBlocks) {
+      b.targets.forEach((_, i) => owned.add(nnBlockReactionKey(b.id, i)));
+    }
+    return owned;
+  });
+
   let query = $state("");
   let filtered = $derived(
     reactions
       .map((rxn, idx) => ({ rxn, idx }))
+      .filter(({ rxn }) => !ownedReactionIds.has(rxn.id))
       .filter(({ rxn }) =>
         fuzzyMatch(defaultValue(rxn.displayName, rxn.id), query),
       ),

--- a/src/lib/TableReactions.svelte
+++ b/src/lib/TableReactions.svelte
@@ -8,7 +8,6 @@
   import {
     defaultTexName,
     defaultValue,
-    nnBlockReactionKey,
     stoichToTex,
   } from "@computational-biology-aachen/mxlweb-core";
   import {
@@ -16,7 +15,7 @@
     Name,
     Num,
   } from "@computational-biology-aachen/mxlweb-core/mathml";
-  import { MediaQuery, SvelteSet } from "svelte/reactivity";
+  import { MediaQuery } from "svelte/reactivity";
   import EqEditor from "./EqEditor.svelte";
   import {
     idToTex,
@@ -60,24 +59,15 @@
     idToTex(variables, parameters, assignments, reactions),
   );
 
-  // An NN block's generated reaction lives in this same `reactions` array
-  // (ModelEditor.svelte's copy is unfiltered, so Save round-trips it
-  // correctly), but must never be an editable/deletable row here (ADR 0005
-  // §2.1.3) — its rate law is machine-generated and changes only through
-  // fitting, never by hand.
-  let ownedReactionIds = $derived.by(() => {
-    const owned = new SvelteSet<string>();
-    for (const b of nnBlocks) {
-      b.targets.forEach((_, i) => owned.add(nnBlockReactionKey(b.id, i)));
-    }
-    return owned;
-  });
-
+  // NN blocks no longer create a reaction at all (ADR 0005's mechanism
+  // selector — a multiplicative block can't be expressed as one more
+  // stoichiometric term, so composition moved to a shared step in
+  // mxlweb-core's ModelBuilderBase.lower() instead) — every row here is
+  // always a genuine hand-authored reaction, no exclusion needed.
   let query = $state("");
   let filtered = $derived(
     reactions
       .map((rxn, idx) => ({ rxn, idx }))
-      .filter(({ rxn }) => !ownedReactionIds.has(rxn.id))
       .filter(({ rxn }) =>
         fuzzyMatch(defaultValue(rxn.displayName, rxn.id), query),
       ),

--- a/src/lib/TableVariables.svelte
+++ b/src/lib/TableVariables.svelte
@@ -16,6 +16,7 @@
   import {
     idToTex,
     type AssView,
+    type NNBlockView,
     type ParView,
     type RxnView,
     type Variable,
@@ -32,11 +33,14 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
+    // eslint-disable-next-line no-useless-assignment
+    nnBlocks = $bindable(),
   }: {
     variables: VarView;
     parameters: ParView;
     assignments: AssView;
     reactions: RxnView;
+    nnBlocks: NNBlockView;
   } = $props();
 
   function onSaveSlider(idx: number, update: Variable) {

--- a/src/lib/TableVariables.svelte
+++ b/src/lib/TableVariables.svelte
@@ -33,7 +33,6 @@
     parameters = $bindable(),
     assignments = $bindable(),
     reactions = $bindable(),
-    // eslint-disable-next-line no-useless-assignment
     nnBlocks = $bindable(),
   }: {
     variables: VarView;
@@ -244,6 +243,7 @@
         parameters={parameters}
         assignments={assignments}
         reactions={reactions}
+        nnBlocks={nnBlocks}
         onSave={(fn) => onSaveInitialAssignment(idx, fn)}
         popovertarget={`var-ia-editor-${idx}`}
       />

--- a/src/lib/modelView.ts
+++ b/src/lib/modelView.ts
@@ -167,6 +167,7 @@ export class ModelView {
         targets: el.targets,
         trained: el.trained,
         scale: el.scale,
+        mechanism: el.mechanism,
       }),
     );
     this.parameters.forEach((el) =>
@@ -238,6 +239,7 @@ export class OdeModelView {
         targets: el.targets,
         trained: el.trained,
         scale: el.scale,
+        mechanism: el.mechanism,
       }),
     );
     this.parameters.forEach((el) =>

--- a/src/lib/modelView.ts
+++ b/src/lib/modelView.ts
@@ -166,6 +166,7 @@ export class ModelView {
         seed: el.seed,
         targets: el.targets,
         trained: el.trained,
+        scale: el.scale,
       }),
     );
     this.parameters.forEach((el) =>
@@ -236,6 +237,7 @@ export class OdeModelView {
         seed: el.seed,
         targets: el.targets,
         trained: el.trained,
+        scale: el.scale,
       }),
     );
     this.parameters.forEach((el) =>

--- a/src/lib/modelView.ts
+++ b/src/lib/modelView.ts
@@ -153,6 +153,21 @@ export class ModelView {
 
   toBuilder(): KineticModelBuilder {
     const builder = new KineticModelBuilder();
+    // NN blocks first, deliberately: addNNBlock always Glorot-reinitializes
+    // its weights fresh from `seed`, so it would clobber any fitting-updated
+    // values already sitting in `this.parameters` if it ran after the
+    // parameter loop below (see ModelBuilderBase.buildMxlweb's identical
+    // ordering and doc comment for the same hazard).
+    this.nnBlocks.forEach((el) =>
+      builder.addNNBlock(el.id, {
+        inputs: el.inputs,
+        depth: el.depth,
+        width: el.width,
+        seed: el.seed,
+        targets: el.targets,
+        trained: el.trained,
+      }),
+    );
     this.parameters.forEach((el) =>
       builder.addParameter(el.id, {
         value: el.value,
@@ -184,21 +199,6 @@ export class ModelView {
         texName: el.texName,
       }),
     );
-    // Last, deliberately: addNNBlock adds Parameters of its own (the block's
-    // weights/biases), and those need this model's other parameters/
-    // variables/reactions already in place to be meaningful once simulated —
-    // matches ADR 0005 §2.1's "a block is wired in like any other reaction"
-    // framing, authored after the rest of the model exists.
-    this.nnBlocks.forEach((el) =>
-      builder.addNNBlock(el.id, {
-        inputs: el.inputs,
-        depth: el.depth,
-        width: el.width,
-        seed: el.seed,
-        targets: el.targets,
-        trained: el.trained,
-      }),
-    );
     return builder;
   }
 }
@@ -224,6 +224,20 @@ export class OdeModelView {
 
   toBuilder(): OdeModelBuilder {
     const builder = new OdeModelBuilder();
+    // NN blocks first, deliberately — see ModelView.toBuilder's identical
+    // ordering and doc comment: addNNBlock always Glorot-reinitializes its
+    // weights fresh from `seed`, which would clobber fitting-updated values
+    // already sitting in `this.parameters` if it ran after that loop.
+    this.nnBlocks.forEach((el) =>
+      builder.addNNBlock(el.id, {
+        inputs: el.inputs,
+        depth: el.depth,
+        width: el.width,
+        seed: el.seed,
+        targets: el.targets,
+        trained: el.trained,
+      }),
+    );
     this.parameters.forEach((el) =>
       builder.addParameter(el.id, {
         value: el.value,
@@ -249,16 +263,6 @@ export class OdeModelView {
     );
     this.variables.forEach((el) =>
       builder.setDifferential(el.id, el.differential),
-    );
-    this.nnBlocks.forEach((el) =>
-      builder.addNNBlock(el.id, {
-        inputs: el.inputs,
-        depth: el.depth,
-        width: el.width,
-        seed: el.seed,
-        targets: el.targets,
-        trained: el.trained,
-      }),
     );
     return builder;
   }

--- a/src/lib/modelView.ts
+++ b/src/lib/modelView.ts
@@ -1,5 +1,6 @@
 import {
   KineticModelBuilder,
+  type NNBlockConfig,
   OdeModelBuilder,
   SteadyStateModelBuilder,
 } from "@computational-biology-aachen/mxlweb-core";
@@ -48,6 +49,11 @@ export type Reaction = {
   texName?: string;
 };
 
+// A UDE/NODE correction term (ADR 0005 in the mxlweb repo, §2.1/§2.1.3) —
+// `id` alongside NNBlockConfig's fields, matching every other *View type's
+// own "list entry needs its own id, the builder-side type doesn't" shape.
+export type NNBlock = NNBlockConfig & { id: string };
+
 // A variable in a direct-ODE model carries its own dx/dt expression.
 export type OdeVariable = Variable & {
   differential: Base;
@@ -60,6 +66,7 @@ export type ParView = Array<Parameter>;
 export type AssView = Array<Assign>;
 export type RxnView = Array<Reaction>;
 export type OdeVarView = Array<OdeVariable>;
+export type NNBlockView = Array<NNBlock>;
 
 export function idToTex(
   variables: Iterable<Variable>,
@@ -128,17 +135,20 @@ export class ModelView {
   variables: VarView = [];
   assignments: AssView = [];
   reactions: RxnView = [];
+  nnBlocks: NNBlockView = [];
 
   constructor(
     parameters: ParView = [],
     variables: VarView = [],
     assignments: AssView = [],
     reactions: RxnView = [],
+    nnBlocks: NNBlockView = [],
   ) {
     this.parameters = parameters;
     this.variables = variables;
     this.assignments = assignments;
     this.reactions = reactions;
+    this.nnBlocks = nnBlocks;
   }
 
   toBuilder(): KineticModelBuilder {
@@ -174,6 +184,21 @@ export class ModelView {
         texName: el.texName,
       }),
     );
+    // Last, deliberately: addNNBlock adds Parameters of its own (the block's
+    // weights/biases), and those need this model's other parameters/
+    // variables/reactions already in place to be meaningful once simulated —
+    // matches ADR 0005 §2.1's "a block is wired in like any other reaction"
+    // framing, authored after the rest of the model exists.
+    this.nnBlocks.forEach((el) =>
+      builder.addNNBlock(el.id, {
+        inputs: el.inputs,
+        depth: el.depth,
+        width: el.width,
+        seed: el.seed,
+        targets: el.targets,
+        trained: el.trained,
+      }),
+    );
     return builder;
   }
 }
@@ -183,15 +208,18 @@ export class OdeModelView {
   parameters: ParView = [];
   variables: OdeVarView = [];
   assignments: AssView = [];
+  nnBlocks: NNBlockView = [];
 
   constructor(
     parameters: ParView = [],
     variables: OdeVarView = [],
     assignments: AssView = [],
+    nnBlocks: NNBlockView = [],
   ) {
     this.parameters = parameters;
     this.variables = variables;
     this.assignments = assignments;
+    this.nnBlocks = nnBlocks;
   }
 
   toBuilder(): OdeModelBuilder {
@@ -221,6 +249,16 @@ export class OdeModelView {
     );
     this.variables.forEach((el) =>
       builder.setDifferential(el.id, el.differential),
+    );
+    this.nnBlocks.forEach((el) =>
+      builder.addNNBlock(el.id, {
+        inputs: el.inputs,
+        depth: el.depth,
+        width: el.width,
+        seed: el.seed,
+        targets: el.targets,
+        trained: el.trained,
+      }),
     );
     return builder;
   }

--- a/src/lib/stores/fitStore.ts
+++ b/src/lib/stores/fitStore.ts
@@ -71,11 +71,11 @@ export class FitSession {
     });
   }
 
-  chunk(maxfev: number) {
+  chunk(maxIterations: number) {
     const req: FitChunkRequest & { type: string } = {
       type: "FIT_CHUNK",
       requestId: this.requestId,
-      maxfev,
+      maxIterations,
     };
     this.worker?.postMessage(req);
   }

--- a/src/routes/dev/eq-editor/+page.svelte
+++ b/src/routes/dev/eq-editor/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import EqEditor from "$lib/EqEditor.svelte";
-  import type { AssView, ParView, RxnView, VarView } from "$lib/modelView";
+  import type {
+    AssView,
+    NNBlockView,
+    ParView,
+    RxnView,
+    VarView,
+  } from "$lib/modelView";
   import {
     Add,
     Divide,
@@ -46,6 +52,7 @@
   const parameters: ParView = [];
   const assignments: AssView = [];
   const reactions: RxnView = [];
+  const nnBlocks: NNBlockView = [];
   let root = $state(initEq());
 </script>
 
@@ -58,6 +65,7 @@
   parameters={parameters}
   assignments={assignments}
   reactions={reactions}
+  nnBlocks={nnBlocks}
   bind:root={root}
   popovertarget="/"
   onSave={() => null}

--- a/tests/modelView.test.ts
+++ b/tests/modelView.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage for a data-loss bug found (twice) during ADR 0005
+ * review: ModelEditor/OdeModelEditor round-trip the live model through
+ * ModelView/OdeModelView.toBuilder() on every Save. A fitted NN block
+ * weight's current value must survive that round-trip untouched, not be
+ * reset to a fresh Glorot-initialized one — see modelView.ts's own comments
+ * on `toBuilder()`'s nnBlocks-before-parameters ordering and on why
+ * ModelEditor.svelte's `parameters`/`reactions` arrays must stay unfiltered
+ * even though the corresponding table UI must not render block-owned rows.
+ */
+import {
+  KineticModelBuilder,
+  OdeModelBuilder,
+  type NNBlockConfig,
+} from "@computational-biology-aachen/mxlweb-core";
+import { describe, expect, it } from "vitest";
+import { ModelView, OdeModelView, type NNBlockView } from "../src/lib/modelView";
+
+const block: NNBlockConfig = {
+  inputs: ["x"],
+  depth: 1,
+  width: 2,
+  seed: 1,
+  targets: ["x"],
+  trained: true,
+};
+
+// Mirrors ModelEditor.svelte's own `parameters`/`nnBlocks` derivations
+// exactly (full parameters, no NN-block exclusion) so this test fails the
+// same way the app would if that filtering crept back in.
+function viewArraysFrom(builder: KineticModelBuilder | OdeModelBuilder) {
+  const parameters = [...builder.parameters.entries()].map(([id, p]) => ({
+    ...p,
+    id,
+    texName: p.texName ?? id,
+  }));
+  const nnBlocks: NNBlockView = [...builder.nnBlocks.entries()].map(
+    ([id, b]) => ({ ...b, id }),
+  );
+  return { parameters, nnBlocks };
+}
+
+describe("ModelView.toBuilder round-trips fitted NN block weights", () => {
+  it("preserves a manually-set weight value, not a fresh Glorot re-init", () => {
+    const builder = new KineticModelBuilder()
+      .addVariable("x", { value: 1 })
+      .addNNBlock("corr", block);
+
+    const weightName = [...builder.parameters.keys()].find((n) =>
+      n.startsWith("corr_w"),
+    )!;
+    // Simulate Fit.svelte's applyFittedParameters writing a fitted value
+    // straight into the live model.
+    const original = builder.parameters.get(weightName)!;
+    builder.parameters = builder.parameters.set(weightName, {
+      ...original,
+      value: 42,
+    });
+
+    const { parameters, nnBlocks } = viewArraysFrom(builder);
+    const variables = [...builder.variables.entries()].map(([id, v]) => ({
+      ...v,
+      id,
+      texName: v.texName ?? id,
+    }));
+    const assignments = [...builder.assignments.entries()].map(([id, a]) => ({
+      ...a,
+      id,
+      texName: a.texName ?? id,
+    }));
+    const reactions = [...builder.reactions.entries()].map(([id, r]) => ({
+      ...r,
+      id,
+      texName: r.texName ?? id,
+    }));
+
+    const rebuilt = new ModelView(
+      parameters,
+      variables,
+      assignments,
+      reactions,
+      nnBlocks,
+    ).toBuilder();
+
+    expect(rebuilt.parameters.get(weightName)?.value).toBe(42);
+  });
+});
+
+describe("OdeModelView.toBuilder round-trips fitted NN block weights", () => {
+  it("preserves a manually-set weight value, not a fresh Glorot re-init", () => {
+    const builder = new OdeModelBuilder()
+      .addVariable("x", { value: 1 })
+      .addNNBlock("corr", block);
+
+    const weightName = [...builder.parameters.keys()].find((n) =>
+      n.startsWith("corr_w"),
+    )!;
+    const original = builder.parameters.get(weightName)!;
+    builder.parameters = builder.parameters.set(weightName, {
+      ...original,
+      value: 42,
+    });
+
+    const { parameters, nnBlocks } = viewArraysFrom(builder);
+    const variables = [...builder.variables.entries()].map(([id, v]) => ({
+      ...v,
+      id,
+      texName: v.texName ?? id,
+      differential: builder.differentials.get(id)!,
+    }));
+    const assignments = [...builder.assignments.entries()].map(([id, a]) => ({
+      ...a,
+      id,
+      texName: a.texName ?? id,
+    }));
+
+    const rebuilt = new OdeModelView(
+      parameters,
+      variables,
+      assignments,
+      nnBlocks,
+    ).toBuilder();
+
+    expect(rebuilt.parameters.get(weightName)?.value).toBe(42);
+  });
+});

--- a/tests/modelView.test.ts
+++ b/tests/modelView.test.ts
@@ -25,6 +25,7 @@ const block: NNBlockConfig = {
   targets: ["x"],
   trained: true,
   scale: 0.1,
+  mechanism: "additive",
 };
 
 // Mirrors ModelEditor.svelte's own `parameters`/`nnBlocks` derivations

--- a/tests/modelView.test.ts
+++ b/tests/modelView.test.ts
@@ -2,9 +2,10 @@
  * Regression coverage for a data-loss bug found (twice) during ADR 0005
  * review: ModelEditor/OdeModelEditor round-trip the live model through
  * ModelView/OdeModelView.toBuilder() on every Save. A fitted NN block
- * weight's current value must survive that round-trip untouched, not be
- * reset to a fresh Glorot-initialized one — see modelView.ts's own comments
- * on `toBuilder()`'s nnBlocks-before-parameters ordering and on why
+ * weight's (or the block's own trainable scale factor's) current value must
+ * survive that round-trip untouched, not be reset to a fresh
+ * Glorot-initialized/default one — see modelView.ts's own comments on
+ * `toBuilder()`'s nnBlocks-before-parameters ordering and on why
  * ModelEditor.svelte's `parameters`/`reactions` arrays must stay unfiltered
  * even though the corresponding table UI must not render block-owned rows.
  */
@@ -23,6 +24,7 @@ const block: NNBlockConfig = {
   seed: 1,
   targets: ["x"],
   trained: true,
+  scale: 0.1,
 };
 
 // Mirrors ModelEditor.svelte's own `parameters`/`nnBlocks` derivations
@@ -41,7 +43,7 @@ function viewArraysFrom(builder: KineticModelBuilder | OdeModelBuilder) {
 }
 
 describe("ModelView.toBuilder round-trips fitted NN block weights", () => {
-  it("preserves a manually-set weight value, not a fresh Glorot re-init", () => {
+  it("preserves a manually-set weight value and a manually-set scale, not a fresh re-init", () => {
     const builder = new KineticModelBuilder()
       .addVariable("x", { value: 1 })
       .addNNBlock("corr", block);
@@ -50,11 +52,18 @@ describe("ModelView.toBuilder round-trips fitted NN block weights", () => {
       n.startsWith("corr_w"),
     )!;
     // Simulate Fit.svelte's applyFittedParameters writing a fitted value
-    // straight into the live model.
+    // straight into the live model — both a weight and the block's own
+    // trainable scale factor (TableNNBlocks.svelte's "Output scale" field
+    // edits the exact same way once the parameter exists).
     const original = builder.parameters.get(weightName)!;
     builder.parameters = builder.parameters.set(weightName, {
       ...original,
       value: 42,
+    });
+    const originalScale = builder.parameters.get("corr_scale")!;
+    builder.parameters = builder.parameters.set("corr_scale", {
+      ...originalScale,
+      value: 7,
     });
 
     const { parameters, nnBlocks } = viewArraysFrom(builder);
@@ -83,11 +92,12 @@ describe("ModelView.toBuilder round-trips fitted NN block weights", () => {
     ).toBuilder();
 
     expect(rebuilt.parameters.get(weightName)?.value).toBe(42);
+    expect(rebuilt.parameters.get("corr_scale")?.value).toBe(7);
   });
 });
 
 describe("OdeModelView.toBuilder round-trips fitted NN block weights", () => {
-  it("preserves a manually-set weight value, not a fresh Glorot re-init", () => {
+  it("preserves a manually-set weight value and a manually-set scale, not a fresh re-init", () => {
     const builder = new OdeModelBuilder()
       .addVariable("x", { value: 1 })
       .addNNBlock("corr", block);
@@ -99,6 +109,11 @@ describe("OdeModelView.toBuilder round-trips fitted NN block weights", () => {
     builder.parameters = builder.parameters.set(weightName, {
       ...original,
       value: 42,
+    });
+    const originalScale = builder.parameters.get("corr_scale")!;
+    builder.parameters = builder.parameters.set("corr_scale", {
+      ...originalScale,
+      value: 7,
     });
 
     const { parameters, nnBlocks } = viewArraysFrom(builder);
@@ -122,5 +137,6 @@ describe("OdeModelView.toBuilder round-trips fitted NN block weights", () => {
     ).toBuilder();
 
     expect(rebuilt.parameters.get(weightName)?.value).toBe(42);
+    expect(rebuilt.parameters.get("corr_scale")?.value).toBe(7);
   });
 });


### PR DESCRIPTION
## Summary

UI-side half of ADR 0005 (`docs/adrs/0005-neural-network-corrections-and-adjoint-fitting.md`) — depends on computational-biology-aachen/mxlweb-core#18.

- New "NN Blocks" tab (`TableNNBlocks.svelte`) on `ModelEditor`/`OdeModelEditor` for authoring/resizing a block (architecture spec, inputs, targets, per-block "trained" toggle) — not supported on `SteadyStateModelEditor` (no dx/dt for a correction term to feed into).
- `Fit.svelte` auto-selects the `"adjoint"` fit backend whenever a trained block is present, folds its weights/biases into the fit in linear space (never log-space), and generates the adjoint WAT lazily.
- A block's generated weights/biases/reaction are kept out of every ordinary listing surface — parameter/reaction tables, `ParameterScanEditor`'s target dropdown, `AnalysesDashboard`'s slider list, `EqEditor`'s symbol-picker autocomplete — per ADR §2.1.3 ("authored/resized as one unit, never individual rows").

## Review history

Went through 4 rounds of independent design-conformance review; rounds 1–3 each found a real bug in the previous round's fix (a save-time weight-clobbering bug, a filter that accidentally reintroduced that same clobbering bug via a different path, and one remaining unfiltered picker in `EqEditor.svelte`). Round 4 found nothing. Added `tests/modelView.test.ts` as permanent regression coverage for the round-trip invariant, verified to actually fail against the pre-fix ordering before being restored.

## Test plan

- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors/warnings (724 files)
- [x] `npx eslint src/lib src/routes` — clean
- [x] `npm run build` — succeeds
- [x] `npx vitest run tests/` — 2/2 passing
- [ ] Not verified in a live browser session (no browser automation available in this environment) — worth a manual pass on the NN Blocks tab and a fit run before merging

## Note for CI

This branch currently resolves `mxlweb-core` against `main`'s pinned SHA in the lockfile (developed locally via `npm link` against computational-biology-aachen/mxlweb-core#18's unmerged commits, since `node_modules`/lockfile pins aren't meant to track an in-review branch). CI here will likely fail to build until mxlweb-core#18 merges and this repo's lockfile gets re-pinned to the fresh `main` SHA (`scripts/lockfile-repin.sh` in the meta-repo) — expected, not a regression in this diff.